### PR TITLE
feat: add Component Output Mode and update README with all v2 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,39 +20,58 @@
 
 No copy-paste. No style hunting. No duplicates.
 
-Currently available as a **Figma plugin**. Sketch support coming.
+Currently available as a **Figma plugin**.
 
 ![Plugin Preview](./assets/preview.png)
 
 ## Features
 
-- **Structured Auto Layout**: Imports markdown as a vertical Auto Layout frame with separate layers for each element.
-  - **Headings** (H1, H2, H3)
-  - **Paragraphs**
-  - **Lists** (Bulleted)
-  - **Code Blocks** (Wrapped in styled frames)
-  - **Tables** (GFM-style with alignment support)
-  - **Images** (Fetched from URLs and embedded)
-- **Automatic Styling**:
-  - Generates local Text Styles (`Markdown/H1`, `Markdown/Body`, etc.) automatically.
-  - Supports inline **Bold** (`**text**`), *Italic* (`*text*`), and `Code` spans.
-- **Table Support**:
-  - Renders GitHub Flavored Markdown tables as Auto Layout frames
-  - Header row with distinct background styling
-  - Supports left, center, and right text alignment (`:---`, `:---:`, `---:`)
-  - Visual cell borders for clear separation
-- **Image Support**:
-  - Automatically fetches and embeds images from URLs
-  - Scales images to fit frame width while maintaining aspect ratio
-  - Error handling with placeholder for failed image loads
-  - Supports standard markdown syntax: `![Alt Text](https://example.com/image.png)`
-- **Smart Font Management**:
-  - Uses `Inter` for UI text and `Roboto Mono` for code.
-  - Handles font loading and fallbacks.
-- **Batch Operations**:
-  - **Drag & Drop**: Simply drag multiple markdown files into the plugin window.
-  - **Auto-Mapping**: Matches file names to existing Frame or Layer names to replace content, or creates new Frames if no match is found.
-- **Content Cleaning**: Automatically strips YAML front matter (`--- ... ---`) to keep your designs clean.
+### Content Types
+
+- **Headings** (H1, H2, H3) with auto-generated text styles
+- **Paragraphs** with full inline formatting
+- **Bullet Lists** with nested sub-bullets (up to 4 depth levels with distinct bullet styles)
+- **Ordered Lists** with automatic numbering and nesting support
+- **Task Lists / Checklists** — `- [ ]` and `- [x]` render as styled checkbox rows
+- **Code Blocks** with language labels, styled background frames
+- **Tables** — GFM-style with left/center/right alignment, header styling, cell borders
+- **Images** — fetched from URLs, scaled to fit frame width with aspect ratio preserved
+- **Blockquotes** with left border styling
+- **Horizontal Rules** as visual separators
+- **Callout / Admonition Blocks** — `> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, `> [!IMPORTANT]`, `> [!CAUTION]` with colored borders, backgrounds, and labels
+- **Definition Lists** — `Term` / `: Definition` syntax with bold terms and indented definitions
+- **Footnotes** — `[^1]` inline references with a collected footnote section at the bottom
+- **Badge / Tag Pills** — `[badge:Label]` or `[badge:Label:color]` rendered as colored pill shapes; also extracts YAML frontmatter `tags`
+- **Mermaid Diagrams** — ` ```mermaid ` code blocks rendered as styled placeholder frames with source
+- **Math / LaTeX Blocks** — `$$ ... $$` rendered as styled frames with the LaTeX source
+- **Table of Contents** — auto-generated from headings (opt-in via settings)
+
+### Inline Formatting
+
+- **Bold** (`**text**`), **Italic** (`*text*`), **Inline Code** (`` `code` ``)
+- **Strikethrough** (`~~text~~`)
+- **Inline Links** (`[text](url)`) with underline decoration and clickable hyperlinks
+
+### Styling & Themes
+
+- **Theme Presets** — Minimal Light, Dark Mode, Documentation, or Custom
+- **Style Binding** — map Markdown elements (H1, Body, Code, etc.) to your existing local Figma text styles instead of generating new ones
+- **Responsive Width Modes** — Narrow (480px), Medium (800px), Wide (960px), or Custom pixel width
+- **Configurable Spacing** — block spacing, list spacing, frame padding
+- **Custom Colors** — code block background, table header background, separator color, frame fill color
+- **Component-Ready Naming** — optional layer naming mode for design system workflows
+- **Component Output Mode** — map block types (code, blockquote, callout, table, image) to your own Figma components; the plugin instantiates them and populates `#content`/`#title` text layers automatically
+
+### Plugin UX
+
+- **Drag & Drop** — drop multiple `.md`, `.markdown`, or `.txt` files at once
+- **Paste Markdown** — paste raw Markdown text directly with an optional custom frame name
+- **Live Preview** — see a styled HTML preview of parsed content before importing to canvas
+- **Selective Block Import** — toggle individual blocks on/off with per-block checkboxes before importing
+- **Import History** — timestamped log of past imports with block counts
+- **In-Place Updates** — matches file names to existing frames and replaces content, preserving position
+- **Batch Operations** — import multiple files simultaneously
+- **Content Cleaning** — automatically strips YAML front matter (`--- ... ---`)
 
 ## Installation
 
@@ -95,14 +114,16 @@ Currently available as a **Figma plugin**. Sketch support coming.
    - If a layer with the same name already exists, it will be **replaced/updated** with the new content, preserving its position.
 
 ### Styles
-The plugin automatically creates the following local styles if they don't exist:
+The plugin automatically creates local text styles if they don't exist:
 - `Markdown/H1`, `Markdown/H2`, `Markdown/H3`
 - `Markdown/Body`
 - `Markdown/Quote`
 - `Markdown/Code`
 - `Markdown/List`
 
-You can edit these styles in Figma to globally update the look of your imported documents!
+You can edit these styles in Figma to globally update the look of your imported documents.
+
+Alternatively, use **Style Binding** in the Settings tab to map each element to your own existing text styles — no `Markdown/*` styles created.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Currently available as a **Figma plugin**.
 - **Configurable Spacing** — block spacing, list spacing, frame padding
 - **Custom Colors** — code block background, table header background, separator color, frame fill color
 - **Component-Ready Naming** — optional layer naming mode for design system workflows
-- **Component Output Mode** — map block types (code, blockquote, callout, table, image) to your own Figma components; the plugin instantiates them and populates `#content`/`#title` text layers automatically
+- **Component Output Mode** — map block types (code, blockquote, callout, table, image) to your own Figma components; the plugin instantiates them and populates `#content` (or `#body`) / `#title` (or `#label`) text layers automatically
 
 ### Plugin UX
 

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -466,18 +466,13 @@ export async function createImageNode(block: Block, settings: PluginSettings): P
         throw new Error('Invalid image block');
     }
 
+    const imageRect = figma.createRectangle();
+    imageRect.name = block.imageAlt || 'Image';
+    imageRect.layoutAlign = 'STRETCH';
+    imageRect.resize(600, 400);
+
     try {
-        const imageRect = figma.createRectangle();
-        imageRect.name = block.imageAlt || 'Image';
-        imageRect.layoutAlign = 'STRETCH';
-
-        // Set default size (will be adjusted after image loads)
-        imageRect.resize(600, 400);
-
-        // Fetch the image asynchronously
         const image = await figma.createImageAsync(block.imageUrl);
-
-        // Get image dimensions
         const imageSize = await image.getSizeAsync();
 
         // Scale image to fit max width while maintaining aspect ratio
@@ -489,7 +484,6 @@ export async function createImageNode(block: Block, settings: PluginSettings): P
             imageRect.resize(imageSize.width, imageSize.height);
         }
 
-        // Apply image fill
         imageRect.fills = [
             {
                 type: 'IMAGE',
@@ -500,7 +494,7 @@ export async function createImageNode(block: Block, settings: PluginSettings): P
 
         return imageRect;
     } catch (error) {
-        // If image loading fails, create a placeholder
+        imageRect.remove();
         console.error(`Failed to load image: ${block.imageUrl}`, error);
 
         const placeholderFrame = figma.createFrame();

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -568,32 +568,34 @@ export async function createErrorPlaceholder(block: Block, reason?: string): Pro
 
 // ─── Component Output Mode ───────────────────────────────────────────────────
 
+const CONTENT_LAYER_NAMES = ['#content', '#body'];
+const TITLE_LAYER_NAMES = ['#title', '#label'];
+
 /**
- * Recursively searches a node tree for a text layer whose name matches one
- * of the given names (e.g. '#content', '#body'). Returns the first match.
+ * Single-pass recursive search for content and title text layers in a component instance.
+ * Returns both in one traversal to avoid walking the tree twice.
  */
-function findTextLayerByName(node: SceneNode, names: string[]): TextNode | null {
-    if (node.type === 'TEXT' && names.includes(node.name)) {
-        return node as TextNode;
+function findComponentLayers(node: SceneNode, result: { content?: TextNode; title?: TextNode }): void {
+    if (node.type === 'TEXT') {
+        if (!result.content && CONTENT_LAYER_NAMES.includes(node.name)) {
+            result.content = node as TextNode;
+        } else if (!result.title && TITLE_LAYER_NAMES.includes(node.name)) {
+            result.title = node as TextNode;
+        }
+        if (result.content && result.title) return;
     }
     if ('children' in node && Array.isArray((node as any).children)) {
         for (const child of (node as FrameNode).children) {
-            const found = findTextLayerByName(child, names);
-            if (found) return found;
+            findComponentLayers(child, result);
+            if (result.content && result.title) return;
         }
     }
-    return null;
 }
 
 /**
  * Attempts to render a block using a component instance from Component Output Mode.
  * Returns the populated instance node if successful, or null if the component
  * binding doesn't exist, the component can't be found, or no #content layer exists.
- *
- * @param block - The block to render
- * @param bindingKey - The key in ComponentBindings to look up
- * @param bindings - The component bindings from settings
- * @param titleText - Optional text for the #title/#label layer
  */
 export async function tryRenderWithComponent(
     block: Block,
@@ -615,30 +617,33 @@ export async function tryRenderWithComponent(
         const instance = (component as ComponentNode).createInstance();
         instance.layoutAlign = 'STRETCH';
 
-        // Find and populate #content / #body text layer
-        const contentLayer = findTextLayerByName(instance, ['#content', '#body']);
-        if (!contentLayer) {
+        // Single-pass search for both content and title layers
+        const layers: { content?: TextNode; title?: TextNode } = {};
+        findComponentLayers(instance, layers);
+
+        if (!layers.content) {
             console.warn(`[MarkDown For What] Component "${component.name}" has no #content or #body text layer — falling back to default rendering`);
             instance.remove();
             return null;
         }
 
-        // Load font used by the content layer before setting characters
-        await figma.loadFontAsync(contentLayer.fontName as FontName);
+        // Load fonts concurrently for content and title layers
+        const fontLoads: Promise<void>[] = [figma.loadFontAsync(layers.content.fontName as FontName)];
+        if (titleText && layers.title) {
+            fontLoads.push(figma.loadFontAsync(layers.title.fontName as FontName));
+        }
+        await Promise.all(fontLoads);
 
+        // Populate content
         if (block.tokens && block.tokens.length > 0) {
-            await applyInlineStyles(contentLayer, block.tokens, STYLE_NAMES.BODY);
+            await applyInlineStyles(layers.content, block.tokens, STYLE_NAMES.BODY);
         } else {
-            contentLayer.characters = block.content ?? '';
+            layers.content.characters = block.content ?? '';
         }
 
-        // Populate optional #title / #label layer
-        if (titleText) {
-            const titleLayer = findTextLayerByName(instance, ['#title', '#label']);
-            if (titleLayer) {
-                await figma.loadFontAsync(titleLayer.fontName as FontName);
-                titleLayer.characters = titleText;
-            }
+        // Populate optional title
+        if (titleText && layers.title) {
+            layers.title.characters = titleText;
         }
 
         return instance;

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Block, CalloutType } from './parser';
-import type { PluginSettings } from './settings';
+import type { PluginSettings, ComponentBindings } from './settings';
 import { resolvedFrameWidth } from './settings';
 import type { marked } from 'marked';
 import { STYLE_NAMES, DEFAULT_STYLES, loadFont, getOrCreateTextStyle, applyInlineStyles } from './styles';
@@ -566,6 +566,88 @@ export async function createErrorPlaceholder(block: Block, reason?: string): Pro
     return errFrame;
 }
 
+// ─── Component Output Mode ───────────────────────────────────────────────────
+
+/**
+ * Recursively searches a node tree for a text layer whose name matches one
+ * of the given names (e.g. '#content', '#body'). Returns the first match.
+ */
+function findTextLayerByName(node: SceneNode, names: string[]): TextNode | null {
+    if (node.type === 'TEXT' && names.includes(node.name)) {
+        return node as TextNode;
+    }
+    if ('children' in node && Array.isArray((node as any).children)) {
+        for (const child of (node as FrameNode).children) {
+            const found = findTextLayerByName(child, names);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+
+/**
+ * Attempts to render a block using a component instance from Component Output Mode.
+ * Returns the populated instance node if successful, or null if the component
+ * binding doesn't exist, the component can't be found, or no #content layer exists.
+ *
+ * @param block - The block to render
+ * @param bindingKey - The key in ComponentBindings to look up
+ * @param bindings - The component bindings from settings
+ * @param titleText - Optional text for the #title/#label layer
+ */
+export async function tryRenderWithComponent(
+    block: Block,
+    bindingKey: keyof ComponentBindings,
+    bindings: ComponentBindings | undefined,
+    titleText?: string,
+): Promise<SceneNode | null> {
+    if (!bindings) return null;
+    const componentId = bindings[bindingKey];
+    if (!componentId) return null;
+
+    try {
+        const component = await figma.getNodeByIdAsync(componentId);
+        if (!component || component.type !== 'COMPONENT') {
+            console.warn(`[MarkDown For What] Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
+            return null;
+        }
+
+        const instance = (component as ComponentNode).createInstance();
+        instance.layoutAlign = 'STRETCH';
+
+        // Find and populate #content / #body text layer
+        const contentLayer = findTextLayerByName(instance, ['#content', '#body']);
+        if (!contentLayer) {
+            console.warn(`[MarkDown For What] Component "${component.name}" has no #content or #body text layer — falling back to default rendering`);
+            instance.remove();
+            return null;
+        }
+
+        // Load font used by the content layer before setting characters
+        await figma.loadFontAsync(contentLayer.fontName as FontName);
+
+        if (block.tokens && block.tokens.length > 0) {
+            await applyInlineStyles(contentLayer, block.tokens, STYLE_NAMES.BODY);
+        } else {
+            contentLayer.characters = block.content ?? '';
+        }
+
+        // Populate optional #title / #label layer
+        if (titleText) {
+            const titleLayer = findTextLayerByName(instance, ['#title', '#label']);
+            if (titleLayer) {
+                await figma.loadFontAsync(titleLayer.fontName as FontName);
+                titleLayer.characters = titleText;
+            }
+        }
+
+        return instance;
+    } catch (err) {
+        console.warn(`[MarkDown For What] Component output failed for "${bindingKey}":`, err);
+        return null;
+    }
+}
+
 // CommonJS export shim — allows Jest (require()) and webpack (import) to both work
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
@@ -581,5 +663,6 @@ if (typeof module !== 'undefined' && module.exports) {
         renderMathBlock,
         createImageNode,
         createErrorPlaceholder,
+        tryRenderWithComponent,
     };
 }

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -566,8 +566,8 @@ export async function createErrorPlaceholder(block: Block, reason?: string): Pro
 
 // ─── Component Output Mode ───────────────────────────────────────────────────
 
-export const CONTENT_LAYER_NAMES = ['#content', '#body'];
-export const TITLE_LAYER_NAMES = ['#title', '#label'];
+const CONTENT_LAYER_NAMES = ['#content', '#body'];
+const TITLE_LAYER_NAMES = ['#title', '#label'];
 
 /** Resolves a TextNode's font name to a concrete FontName, narrowing past the `FontName | typeof figma.mixed` union. */
 function resolvedFontName(node: TextNode): FontName {
@@ -639,10 +639,6 @@ export async function tryRenderWithComponent(
             const node = await figma.getNodeByIdAsync(componentId);
             component = (node && node.type === 'COMPONENT') ? node as ComponentNode : null;
             componentCache.set(componentId, component);
-            // Log only on cache miss to avoid repeating the same error for every block
-            if (!component) {
-                console.error(`[MarkDown For What] Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
-            }
         }
         if (!component) {
             throw new Error(`Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -4,13 +4,10 @@
  * Individual block-level renderers extracted from renderer.ts.
  * Each function converts a single Block into a Figma SceneNode.
  *
- * This module handles:
- *   - Callout/admonition blocks
- *   - Table of contents blocks
- *   - List item blocks (unordered, ordered, task)
- *   - Image blocks (with placeholder fallback)
- *   - Error placeholder blocks
- *   - Component Output Mode rendering (tryRenderWithComponent)
+ * This module handles all block-level renderers (callout, TOC, list, ordered
+ * list, task list, definition list, footnote section, badge row, mermaid, math,
+ * image, error placeholder) and Component Output Mode rendering
+ * (tryRenderWithComponent).
  *
  * The orchestration (renderBlocks, renderBlock dispatch) stays in renderer.ts.
  */
@@ -569,8 +566,15 @@ export async function createErrorPlaceholder(block: Block, reason?: string): Pro
 
 // ─── Component Output Mode ───────────────────────────────────────────────────
 
-const CONTENT_LAYER_NAMES = ['#content', '#body'];
-const TITLE_LAYER_NAMES = ['#title', '#label'];
+export const CONTENT_LAYER_NAMES = ['#content', '#body'];
+export const TITLE_LAYER_NAMES = ['#title', '#label'];
+
+/** Resolves a TextNode's font name to a concrete FontName, narrowing past the `FontName | typeof figma.mixed` union. */
+function resolvedFontName(node: TextNode): FontName {
+    return node.fontName === figma.mixed
+        ? node.getRangeFontName(0, 1) as FontName
+        : node.fontName as FontName;
+}
 
 /**
  * Single-pass recursive search for content and title text layers in a component instance.
@@ -594,10 +598,27 @@ function findComponentLayers(node: SceneNode, result: { content?: TextNode; titl
 }
 
 /**
+ * Module-level cache for component lookups, cleared at the start of each
+ * renderBlocks() call via clearComponentCache(). Avoids repeated
+ * getNodeByIdAsync calls within a single render pass.
+ */
+const componentCache = new Map<string, ComponentNode | null>();
+
+/** Clears the component lookup cache. Called at the start of each renderBlocks() pass. */
+export function clearComponentCache(): void {
+    componentCache.clear();
+}
+
+/**
  * Attempts to render a block using a component instance from Component Output Mode.
- * Returns the populated instance node if successful, or null if: bindings are not
- * configured, the binding key is absent, the component can't be found, the node is
- * not a COMPONENT type, no #content layer exists, or an error occurs during instantiation.
+ * Returns the populated instance node if successful, or null if bindings are not
+ * configured or the binding key is absent (i.e. "not configured" — caller falls
+ * through to default rendering).
+ *
+ * Throws on errors so the caller can insert a visible error placeholder rather
+ * than silently falling back. Also throws when the component can't be found or
+ * has no #content layer — these indicate a misconfigured binding that the user
+ * should see.
  */
 export async function tryRenderWithComponent(
     block: Block,
@@ -611,34 +632,37 @@ export async function tryRenderWithComponent(
 
     let instance: InstanceNode | undefined;
     try {
-        const component = await figma.getNodeByIdAsync(componentId);
-        if (!component || component.type !== 'COMPONENT') {
-            console.error(`[MarkDown For What] Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
-            return null;
+        let component: ComponentNode | null;
+        if (componentCache.has(componentId)) {
+            component = componentCache.get(componentId)!;
+        } else {
+            const node = await figma.getNodeByIdAsync(componentId);
+            component = (node && node.type === 'COMPONENT') ? node as ComponentNode : null;
+            componentCache.set(componentId, component);
+            // Log only on cache miss to avoid repeating the same error for every block
+            if (!component) {
+                console.error(`[MarkDown For What] Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
+            }
+        }
+        if (!component) {
+            throw new Error(`Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
         }
 
-        instance = (component as ComponentNode).createInstance();
+        instance = component.createInstance();
         instance.layoutAlign = 'STRETCH';
 
         const layers: { content?: TextNode; title?: TextNode } = {};
         findComponentLayers(instance, layers);
 
         if (!layers.content) {
-            console.error(`[MarkDown For What] Component "${component.name}" has no #content or #body text layer — falling back to default rendering`);
             instance.remove();
-            return null;
+            throw new Error(`Component "${component.name}" has no #content or #body text layer`);
         }
 
         // Load fonts concurrently for content and title layers
-        const contentFontName = layers.content.fontName === figma.mixed
-            ? layers.content.getRangeFontName(0, 1) as FontName
-            : layers.content.fontName as FontName;
-        const fontLoads: Promise<void>[] = [figma.loadFontAsync(contentFontName)];
+        const fontLoads: Promise<void>[] = [figma.loadFontAsync(resolvedFontName(layers.content))];
         if (titleText && layers.title) {
-            const titleFontName = layers.title.fontName === figma.mixed
-                ? layers.title.getRangeFontName(0, 1) as FontName
-                : layers.title.fontName as FontName;
-            fontLoads.push(figma.loadFontAsync(titleFontName));
+            fontLoads.push(figma.loadFontAsync(resolvedFontName(layers.title)));
         }
         await Promise.all(fontLoads);
 
@@ -654,9 +678,8 @@ export async function tryRenderWithComponent(
 
         return instance;
     } catch (err) {
-        console.error(`[MarkDown For What] Component output failed for "${bindingKey}":`, err);
         if (instance) instance.remove();
-        return null;
+        throw err;
     }
 }
 
@@ -676,5 +699,6 @@ if (typeof module !== 'undefined' && module.exports) {
         createImageNode,
         createErrorPlaceholder,
         tryRenderWithComponent,
+        clearComponentCache,
     };
 }

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -10,6 +10,7 @@
  *   - List item blocks (unordered, ordered, task)
  *   - Image blocks (with placeholder fallback)
  *   - Error placeholder blocks
+ *   - Component Output Mode rendering (tryRenderWithComponent)
  *
  * The orchestration (renderBlocks, renderBlock dispatch) stays in renderer.ts.
  */
@@ -573,7 +574,7 @@ const TITLE_LAYER_NAMES = ['#title', '#label'];
 
 /**
  * Single-pass recursive search for content and title text layers in a component instance.
- * Returns both in one traversal to avoid walking the tree twice.
+ * Populates both fields of the `result` object in one traversal to avoid walking the tree twice.
  */
 function findComponentLayers(node: SceneNode, result: { content?: TextNode; title?: TextNode }): void {
     if (node.type === 'TEXT') {
@@ -594,8 +595,9 @@ function findComponentLayers(node: SceneNode, result: { content?: TextNode; titl
 
 /**
  * Attempts to render a block using a component instance from Component Output Mode.
- * Returns the populated instance node if successful, or null if the component
- * binding doesn't exist, the component can't be found, or no #content layer exists.
+ * Returns the populated instance node if successful, or null if: bindings are not
+ * configured, the binding key is absent, the component can't be found, the node is
+ * not a COMPONENT type, no #content layer exists, or an error occurs during instantiation.
  */
 export async function tryRenderWithComponent(
     block: Block,
@@ -607,48 +609,53 @@ export async function tryRenderWithComponent(
     const componentId = bindings[bindingKey];
     if (!componentId) return null;
 
+    let instance: InstanceNode | undefined;
     try {
         const component = await figma.getNodeByIdAsync(componentId);
         if (!component || component.type !== 'COMPONENT') {
-            console.warn(`[MarkDown For What] Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
+            console.error(`[MarkDown For What] Component binding "${bindingKey}" points to non-existent or non-component node: ${componentId}`);
             return null;
         }
 
-        const instance = (component as ComponentNode).createInstance();
+        instance = (component as ComponentNode).createInstance();
         instance.layoutAlign = 'STRETCH';
 
-        // Single-pass search for both content and title layers
         const layers: { content?: TextNode; title?: TextNode } = {};
         findComponentLayers(instance, layers);
 
         if (!layers.content) {
-            console.warn(`[MarkDown For What] Component "${component.name}" has no #content or #body text layer — falling back to default rendering`);
+            console.error(`[MarkDown For What] Component "${component.name}" has no #content or #body text layer — falling back to default rendering`);
             instance.remove();
             return null;
         }
 
         // Load fonts concurrently for content and title layers
-        const fontLoads: Promise<void>[] = [figma.loadFontAsync(layers.content.fontName as FontName)];
+        const contentFontName = layers.content.fontName === figma.mixed
+            ? layers.content.getRangeFontName(0, 1) as FontName
+            : layers.content.fontName as FontName;
+        const fontLoads: Promise<void>[] = [figma.loadFontAsync(contentFontName)];
         if (titleText && layers.title) {
-            fontLoads.push(figma.loadFontAsync(layers.title.fontName as FontName));
+            const titleFontName = layers.title.fontName === figma.mixed
+                ? layers.title.getRangeFontName(0, 1) as FontName
+                : layers.title.fontName as FontName;
+            fontLoads.push(figma.loadFontAsync(titleFontName));
         }
         await Promise.all(fontLoads);
 
-        // Populate content
         if (block.tokens && block.tokens.length > 0) {
             await applyInlineStyles(layers.content, block.tokens, STYLE_NAMES.BODY);
         } else {
             layers.content.characters = block.content ?? '';
         }
 
-        // Populate optional title
         if (titleText && layers.title) {
             layers.title.characters = titleText;
         }
 
         return instance;
     } catch (err) {
-        console.warn(`[MarkDown For What] Component output failed for "${bindingKey}":`, err);
+        console.error(`[MarkDown For What] Component output failed for "${bindingKey}":`, err);
+        if (instance) instance.remove();
         return null;
     }
 }

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -72,7 +72,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
 
         if (msg.type === 'get-local-components') {
             try {
-                const components = figma.currentPage.findAll(n => n.type === 'COMPONENT') as ComponentNode[];
+                const components = figma.currentPage.findAllWithCriteria({ types: ['COMPONENT'] }) as ComponentNode[];
                 figma.ui.postMessage({
                     type: 'local-components',
                     components: components.map(c => ({ id: c.id, name: c.name })),

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -3,6 +3,12 @@ import { DEFAULT_SETTINGS, loadSettings, saveSettings, loadHistory, recordImport
 import { loadFont } from './styles';
 import { renderBlocks, RenderResult } from './renderer';
 import { errorMessage } from './utils';
+import {
+    MSG_GET_SETTINGS, MSG_SAVE_SETTINGS, MSG_RESET_SETTINGS,
+    MSG_GET_LOCAL_STYLES, MSG_GET_LOCAL_COMPONENTS,
+    MSG_GET_HISTORY, MSG_CLEAR_HISTORY, MSG_IMPORT_BATCH,
+    MSG_STATUS, MSG_SETTINGS, MSG_LOCAL_STYLES, MSG_LOCAL_COMPONENTS, MSG_HISTORY,
+} from './messages';
 
 // Initialize UI — 400×500 px panel, Figma Design only (not FigJam or Slides)
 figma.showUI(__html__, { width: 400, height: 500 });
@@ -17,23 +23,23 @@ figma.showUI(__html__, { width: 400, height: 500 });
     // Message handler — processes: get-settings, save-settings, reset-settings, import-markdown-batch
     figma.ui.onmessage = async (msg) => {
     try {
-        if (msg.type === 'get-settings') {
+        if (msg.type === MSG_GET_SETTINGS) {
             const settings = await loadSettings();
-            figma.ui.postMessage({ type: 'settings', settings });
+            figma.ui.postMessage({ type: MSG_SETTINGS, settings });
             return;
         }
 
-        if (msg.type === 'save-settings') {
+        if (msg.type === MSG_SAVE_SETTINGS) {
             if (!msg.settings || typeof msg.settings !== 'object') {
-                figma.ui.postMessage({ type: 'status', message: 'Invalid settings payload.', error: true });
+                figma.ui.postMessage({ type: MSG_STATUS, message: 'Invalid settings payload.', error: true });
                 return;
             }
             try {
                 await saveSettings(msg.settings);
-                figma.ui.postMessage({ type: 'status', message: 'Settings saved.', error: false });
+                figma.ui.postMessage({ type: MSG_STATUS, message: 'Settings saved.', error: false });
             } catch (saveErr) {
                 figma.ui.postMessage({
-                    type: 'status',
+                    type: MSG_STATUS,
                     message: `Failed to save settings: ${errorMessage(saveErr)}`,
                     error: true
                 });
@@ -41,14 +47,14 @@ figma.showUI(__html__, { width: 400, height: 500 });
             return;
         }
 
-        if (msg.type === 'reset-settings') {
+        if (msg.type === MSG_RESET_SETTINGS) {
             try {
                 await saveSettings(DEFAULT_SETTINGS);
-                figma.ui.postMessage({ type: 'settings', settings: DEFAULT_SETTINGS });
-                figma.ui.postMessage({ type: 'status', message: 'Settings reset to defaults.', error: false });
+                figma.ui.postMessage({ type: MSG_SETTINGS, settings: DEFAULT_SETTINGS });
+                figma.ui.postMessage({ type: MSG_STATUS, message: 'Settings reset to defaults.', error: false });
             } catch (err) {
                 figma.ui.postMessage({
-                    type: 'status',
+                    type: MSG_STATUS,
                     message: `Failed to reset settings: ${errorMessage(err)}`,
                     error: true,
                 });
@@ -56,52 +62,52 @@ figma.showUI(__html__, { width: 400, height: 500 });
             return;
         }
 
-        if (msg.type === 'get-local-styles') {
+        if (msg.type === MSG_GET_LOCAL_STYLES) {
             try {
                 const textStyles = await figma.getLocalTextStylesAsync();
                 figma.ui.postMessage({
-                    type: 'local-styles',
+                    type: MSG_LOCAL_STYLES,
                     textStyles: textStyles.map((s: any) => ({ id: s.id, name: s.name })),
                 });
             } catch (err) {
                 console.error('[MarkDown For What] Failed to fetch local styles:', err);
-                figma.ui.postMessage({ type: 'local-styles', textStyles: [] });
+                figma.ui.postMessage({ type: MSG_LOCAL_STYLES, textStyles: [] });
             }
             return;
         }
 
-        if (msg.type === 'get-local-components') {
+        if (msg.type === MSG_GET_LOCAL_COMPONENTS) {
             try {
                 const components = figma.currentPage.findAllWithCriteria({ types: ['COMPONENT'] }) as ComponentNode[];
                 figma.ui.postMessage({
-                    type: 'local-components',
+                    type: MSG_LOCAL_COMPONENTS,
                     components: components.map(c => ({ id: c.id, name: c.name })),
                 });
             } catch (err) {
                 console.error('[MarkDown For What] Failed to fetch local components:', err);
-                figma.ui.postMessage({ type: 'local-components', components: [] });
+                figma.ui.postMessage({ type: MSG_LOCAL_COMPONENTS, components: [] });
             }
             return;
         }
 
-        if (msg.type === 'get-history') {
+        if (msg.type === MSG_GET_HISTORY) {
             const history = await loadHistory();
-            figma.ui.postMessage({ type: 'history', entries: history });
+            figma.ui.postMessage({ type: MSG_HISTORY, entries: history });
             return;
         }
 
-        if (msg.type === 'clear-history') {
+        if (msg.type === MSG_CLEAR_HISTORY) {
             await clearHistory();
-            figma.ui.postMessage({ type: 'history', entries: [] });
-            figma.ui.postMessage({ type: 'status', message: 'Import history cleared.', error: false });
+            figma.ui.postMessage({ type: MSG_HISTORY, entries: [] });
+            figma.ui.postMessage({ type: MSG_STATUS, message: 'Import history cleared.', error: false });
             return;
         }
 
-        if (msg.type === 'import-markdown-batch') {
+        if (msg.type === MSG_IMPORT_BATCH) {
             const files = msg.files;
 
             if (!files || files.length === 0) {
-                figma.ui.postMessage({ type: 'status', message: 'No files request received.', error: true });
+                figma.ui.postMessage({ type: MSG_STATUS, message: 'No files request received.', error: true });
                 return;
             }
 
@@ -118,7 +124,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
             if (fontResults.some(r => r.status === 'rejected')) {
                 console.warn('[MarkDown For What] Font pre-load partial failure — rendering will use available fallbacks:', fontResults);
                 figma.ui.postMessage({
-                    type: 'status',
+                    type: MSG_STATUS,
                     message: 'Warning: some fonts unavailable. Output may use fallback fonts.',
                     warning: true
                 });
@@ -155,7 +161,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                     failedCount++;
                     console.error(`Failed to import ${file.name}`, e);
                     figma.ui.postMessage({
-                        type: 'status',
+                        type: MSG_STATUS,
                         message: `Error importing ${file.name}: ${errorMessage(e)}`,
                         error: true
                     });
@@ -171,7 +177,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
             }
 
             figma.ui.postMessage({
-                type: 'status',
+                type: MSG_STATUS,
                 message: statusMessage,
                 error: failedCount > 0
             });
@@ -179,7 +185,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
     } catch (err) {
         console.error('[MarkDown For What] Unhandled error in message handler:', err);
         figma.ui.postMessage({
-            type: 'status',
+            type: MSG_STATUS,
             message: `Unexpected error: ${errorMessage(err)}`,
             error: true
         });

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -70,6 +70,20 @@ figma.showUI(__html__, { width: 400, height: 500 });
             return;
         }
 
+        if (msg.type === 'get-local-components') {
+            try {
+                const components = figma.currentPage.findAll(n => n.type === 'COMPONENT') as ComponentNode[];
+                figma.ui.postMessage({
+                    type: 'local-components',
+                    components: components.map(c => ({ id: c.id, name: c.name })),
+                });
+            } catch (err) {
+                console.error('[MarkDown For What] Failed to fetch local components:', err);
+                figma.ui.postMessage({ type: 'local-components', components: [] });
+            }
+            return;
+        }
+
         if (msg.type === 'get-history') {
             const history = await loadHistory();
             figma.ui.postMessage({ type: 'history', entries: history });

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -85,7 +85,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 });
             } catch (err) {
                 console.error('[MarkDown For What] Failed to fetch local components:', err);
-                figma.ui.postMessage({ type: MSG_LOCAL_COMPONENTS, components: [] });
+                figma.ui.postMessage({ type: MSG_LOCAL_COMPONENTS, components: [], error: 'Failed to load components from the current page.' });
             }
             return;
         }
@@ -156,7 +156,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                     updatedCount++;
                     totalImageFailures += result.imageFailures;
                     // Record in import history (fire-and-forget — don't block render)
-                    recordImport(file.name, blocks.length).catch(() => {});
+                    recordImport(file.name, blocks.length).catch(err => { console.error('[MarkDown For What] Failed to record import history:', err); });
                 } catch (e) {
                     failedCount++;
                     console.error(`Failed to import ${file.name}`, e);

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -20,7 +20,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
         return;
     }
 
-    // Message handler — processes: get-settings, save-settings, reset-settings, import-markdown-batch
+    // Message handler — see messages.ts for all supported message types
     figma.ui.onmessage = async (msg) => {
     try {
         if (msg.type === MSG_GET_SETTINGS) {

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -125,11 +125,15 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 loadFont('Inter', 'Bold Italic'),
                 loadFont('Roboto Mono', 'Regular'),
             ]);
-            if (fontResults.some(r => r.status === 'rejected')) {
-                console.warn('[MarkDown For What] Font pre-load partial failure — rendering will use available fallbacks:', fontResults);
+            const fontNames = ['Inter Regular', 'Inter Bold', 'Inter Italic', 'Inter Bold Italic', 'Roboto Mono Regular'];
+            const failedFonts = fontResults
+                .map((r, i) => r.status === 'rejected' ? fontNames[i] : null)
+                .filter(Boolean);
+            if (failedFonts.length > 0) {
+                console.warn('[MarkDown For What] Failed to load fonts:', failedFonts.join(', '));
                 figma.ui.postMessage({
                     type: MSG_STATUS,
-                    message: 'Warning: some fonts unavailable. Output may use fallback fonts.',
+                    message: `Warning: could not load fonts: ${failedFonts.join(', ')}. Output may use fallback fonts.`,
                     warning: true
                 });
             }

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -71,7 +71,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 });
             } catch (err) {
                 console.error('[MarkDown For What] Failed to fetch local styles:', err);
-                figma.ui.postMessage({ type: MSG_LOCAL_STYLES, textStyles: [] });
+                figma.ui.postMessage({ type: MSG_LOCAL_STYLES, textStyles: [], error: 'Failed to load text styles.' });
             }
             return;
         }
@@ -97,9 +97,13 @@ figma.showUI(__html__, { width: 400, height: 500 });
         }
 
         if (msg.type === MSG_CLEAR_HISTORY) {
-            await clearHistory();
-            figma.ui.postMessage({ type: MSG_HISTORY, entries: [] });
-            figma.ui.postMessage({ type: MSG_STATUS, message: 'Import history cleared.', error: false });
+            try {
+                await clearHistory();
+                figma.ui.postMessage({ type: MSG_HISTORY, entries: [] });
+                figma.ui.postMessage({ type: MSG_STATUS, message: 'Import history cleared.', error: false });
+            } catch (err) {
+                figma.ui.postMessage({ type: MSG_STATUS, message: `Failed to clear history: ${errorMessage(err)}`, error: true });
+            }
             return;
         }
 

--- a/figma-markdown-sync/messages.ts
+++ b/figma-markdown-sync/messages.ts
@@ -1,0 +1,27 @@
+/**
+ * messages.ts
+ *
+ * Shared message type constants for communication between the plugin sandbox
+ * (code.ts) and the UI iframe (ui.ts). Both bundles import from here so
+ * message types are defined in a single place — a typo becomes a compile
+ * error instead of a silent mismatch.
+ */
+
+// ── UI → Sandbox (requests) ──────────────────────────────────────────────────
+
+export const MSG_GET_SETTINGS         = 'get-settings';
+export const MSG_SAVE_SETTINGS        = 'save-settings';
+export const MSG_RESET_SETTINGS       = 'reset-settings';
+export const MSG_GET_LOCAL_STYLES     = 'get-local-styles';
+export const MSG_GET_LOCAL_COMPONENTS = 'get-local-components';
+export const MSG_GET_HISTORY          = 'get-history';
+export const MSG_CLEAR_HISTORY        = 'clear-history';
+export const MSG_IMPORT_BATCH         = 'import-markdown-batch';
+
+// ── Sandbox → UI (responses) ─────────────────────────────────────────────────
+
+export const MSG_STATUS           = 'status';
+export const MSG_SETTINGS         = 'settings';
+export const MSG_LOCAL_STYLES     = 'local-styles';
+export const MSG_LOCAL_COMPONENTS = 'local-components';
+export const MSG_HISTORY          = 'history';

--- a/figma-markdown-sync/renderer.test.ts
+++ b/figma-markdown-sync/renderer.test.ts
@@ -951,7 +951,32 @@ describe('renderBlocks', () => {
     });
 
     describe('component output mode', () => {
-        it('should fall back to default rendering when component binding points to non-existent node', async () => {
+        /** Creates a mock TextNode for component output mode tests. */
+        function makeMockTextLayer(name: string, fontStyle = 'Regular'): any {
+            return {
+                type: 'TEXT',
+                name,
+                characters: '',
+                fontName: { family: 'Inter', style: fontStyle },
+                fontSize: 16,
+                fills: [],
+                layoutAlign: 'MIN',
+                layoutGrow: 0,
+                textAlignHorizontal: 'LEFT',
+                paragraphIndent: 0,
+                opacity: 1,
+                parent: null,
+                setRangeFontName: jest.fn(),
+                setRangeTextDecoration: jest.fn(),
+                setRangeHyperlink: jest.fn(),
+                setRangeFills: jest.fn(),
+                insertCharacters: jest.fn(),
+                remove: jest.fn(),
+                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
+            };
+        }
+
+        it('should show error placeholder when component binding points to non-existent node', async () => {
             (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(null);
             const blocks: Block[] = [
                 { type: 'code', content: 'console.log("hi")', language: 'js' },
@@ -962,12 +987,11 @@ describe('renderBlocks', () => {
             };
             const result = await renderBlocks('test', blocks, settings);
             expect(result.frame.children.length).toBe(1);
-            // Should render as normal code frame, not crash
+            // Should show error placeholder since component binding was configured but failed
             expect(result.frame.children[0].type).toBe('FRAME');
         });
 
-        it('should fall back when component has no #content layer', async () => {
-            // Mock a component node whose instance has no #content layer
+        it('should show error placeholder when component has no #content layer', async () => {
             const mockInstance = {
                 type: 'INSTANCE',
                 layoutAlign: 'MIN',
@@ -991,33 +1015,13 @@ describe('renderBlocks', () => {
                 componentBindings: { codeBlock: 'comp-123' },
             };
             const result = await renderBlocks('test', blocks, settings);
-            // Should fall back and render as normal code frame
             expect(mockInstance.remove).toHaveBeenCalled();
+            // Should show error placeholder, not silently fall back
             expect(result.frame.children[0].type).toBe('FRAME');
         });
 
         it('should use component instance when #content layer exists', async () => {
-            const contentLayer = {
-                type: 'TEXT',
-                name: '#content',
-                characters: '',
-                fontName: { family: 'Inter', style: 'Regular' },
-                fontSize: 16,
-                fills: [],
-                layoutAlign: 'MIN',
-                layoutGrow: 0,
-                textAlignHorizontal: 'LEFT',
-                paragraphIndent: 0,
-                opacity: 1,
-                parent: null,
-                setRangeFontName: jest.fn(),
-                setRangeTextDecoration: jest.fn(),
-                setRangeHyperlink: jest.fn(),
-                setRangeFills: jest.fn(),
-                insertCharacters: jest.fn(),
-                remove: jest.fn(),
-                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
-            };
+            const contentLayer = makeMockTextLayer('#content');
             const mockInstance = {
                 type: 'INSTANCE',
                 name: 'My Code Block',
@@ -1040,55 +1044,142 @@ describe('renderBlocks', () => {
                 componentBindings: { blockquote: 'comp-456' },
             };
             const result = await renderBlocks('test', blocks, settings);
-            // Should use the component instance
             expect(mockComponent.createInstance).toHaveBeenCalled();
             expect(contentLayer.characters).toBe('A wise saying');
             expect(result.frame.children[0]).toBe(mockInstance);
         });
 
+        it('should find #body layer as alternative to #content', async () => {
+            const bodyLayer = makeMockTextLayer('#body');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Quote Component',
+                layoutAlign: 'MIN',
+                children: [bodyLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Quote Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Body layer test' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-body-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(bodyLayer.characters).toBe('Body layer test');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should find #label layer as alternative to #title', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const labelLayer = makeMockTextLayer('#label', 'Bold');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Callout Component',
+                layoutAlign: 'MIN',
+                children: [labelLayer, contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Callout Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'callout', calloutType: 'tip', content: 'Label test' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { callout: 'comp-label-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(labelLayer.characters).toBe('tip');
+            expect(contentLayer.characters).toBe('Label test');
+        });
+
+        it('should find #content layer nested inside frames', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Nested Component',
+                layoutAlign: 'MIN',
+                children: [
+                    {
+                        type: 'FRAME',
+                        name: 'wrapper',
+                        children: [
+                            {
+                                type: 'FRAME',
+                                name: 'inner',
+                                children: [contentLayer],
+                            },
+                        ],
+                    },
+                ],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Nested Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Deeply nested' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-nested-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(contentLayer.characters).toBe('Deeply nested');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should handle figma.mixed fontName by using getRangeFontName', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            contentLayer.fontName = figma.mixed;
+            contentLayer.getRangeFontName = jest.fn().mockReturnValue({ family: 'Roboto', style: 'Bold' });
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Mixed Font Component',
+                layoutAlign: 'MIN',
+                children: [contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Mixed Font Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Mixed font test' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-mixed-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(contentLayer.getRangeFontName).toHaveBeenCalledWith(0, 1);
+            expect(contentLayer.characters).toBe('Mixed font test');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
         it('should populate #title layer from calloutType', async () => {
-            const contentLayer = {
-                type: 'TEXT',
-                name: '#content',
-                characters: '',
-                fontName: { family: 'Inter', style: 'Regular' },
-                fontSize: 16,
-                fills: [],
-                layoutAlign: 'MIN',
-                layoutGrow: 0,
-                textAlignHorizontal: 'LEFT',
-                paragraphIndent: 0,
-                opacity: 1,
-                parent: null,
-                setRangeFontName: jest.fn(),
-                setRangeTextDecoration: jest.fn(),
-                setRangeHyperlink: jest.fn(),
-                setRangeFills: jest.fn(),
-                insertCharacters: jest.fn(),
-                remove: jest.fn(),
-                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
-            };
-            const titleLayer = {
-                type: 'TEXT',
-                name: '#title',
-                characters: '',
-                fontName: { family: 'Inter', style: 'Bold' },
-                fontSize: 14,
-                fills: [],
-                layoutAlign: 'MIN',
-                layoutGrow: 0,
-                textAlignHorizontal: 'LEFT',
-                paragraphIndent: 0,
-                opacity: 1,
-                parent: null,
-                setRangeFontName: jest.fn(),
-                setRangeTextDecoration: jest.fn(),
-                setRangeHyperlink: jest.fn(),
-                setRangeFills: jest.fn(),
-                insertCharacters: jest.fn(),
-                remove: jest.fn(),
-                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
-            };
+            const contentLayer = makeMockTextLayer('#content');
+            const titleLayer = makeMockTextLayer('#title', 'Bold');
             const mockInstance = {
                 type: 'INSTANCE',
                 name: 'Callout Component',
@@ -1117,28 +1208,36 @@ describe('renderBlocks', () => {
             expect(result.frame.children[0]).toBe(mockInstance);
         });
 
-        it('should use applyInlineStyles when block has tokens in component mode', async () => {
-            const contentLayer = {
-                type: 'TEXT',
-                name: '#content',
-                characters: '',
-                fontName: { family: 'Inter', style: 'Regular' },
-                fontSize: 16,
-                fills: [],
+        it('should render successfully when titleText provided but no #title layer exists', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Callout No Title',
                 layoutAlign: 'MIN',
-                layoutGrow: 0,
-                textAlignHorizontal: 'LEFT',
-                paragraphIndent: 0,
-                opacity: 1,
-                parent: null,
-                setRangeFontName: jest.fn(),
-                setRangeTextDecoration: jest.fn(),
-                setRangeHyperlink: jest.fn(),
-                setRangeFills: jest.fn(),
-                insertCharacters: jest.fn(),
+                children: [contentLayer],
                 remove: jest.fn(),
-                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
             };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Callout No Title',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'callout', calloutType: 'warning', content: 'No title layer' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { callout: 'comp-no-title-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(contentLayer.characters).toBe('No title layer');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should use applyInlineStyles when block has tokens in component mode', async () => {
+            const contentLayer = makeMockTextLayer('#content');
             const mockInstance = {
                 type: 'INSTANCE',
                 name: 'Quote Component',
@@ -1170,14 +1269,12 @@ describe('renderBlocks', () => {
             };
             const result = await renderBlocks('test', blocks, settings);
             expect(mockComponent.createInstance).toHaveBeenCalled();
-            // When tokens are present, applyInlineStyles sets .characters from flattened
-            // token text and calls setRangeFontName for formatting ranges
             expect(contentLayer.characters).toBe('bold text');
             expect(contentLayer.setRangeFontName).toHaveBeenCalled();
             expect(result.frame.children[0]).toBe(mockInstance);
         });
 
-        it('should fall back when component node type is FRAME instead of COMPONENT', async () => {
+        it('should show error placeholder when component node type is FRAME instead of COMPONENT', async () => {
             const mockFrameNode = {
                 type: 'FRAME',
                 name: 'Not A Component',
@@ -1192,12 +1289,12 @@ describe('renderBlocks', () => {
                 componentBindings: { codeBlock: 'frame-id-999' },
             };
             const result = await renderBlocks('test', blocks, settings);
-            // Should fall back to default code frame rendering
+            // Should show error placeholder since binding was misconfigured
             expect(result.frame.children.length).toBe(1);
             expect(result.frame.children[0].type).toBe('FRAME');
         });
 
-        it('should return null and fall back when createInstance throws', async () => {
+        it('should show error placeholder when createInstance throws', async () => {
             const mockComponent = {
                 type: 'COMPONENT',
                 name: 'Broken Component',
@@ -1206,16 +1303,16 @@ describe('renderBlocks', () => {
             (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
 
             const blocks: Block[] = [
-                { type: 'quote', content: 'Should still render' },
+                { type: 'quote', content: 'Should show error' },
             ];
             const settings = {
                 ...DEFAULT_SETTINGS,
                 componentBindings: { blockquote: 'comp-broken-1' },
             };
             const result = await renderBlocks('test', blocks, settings);
-            // Should not crash — falls back to default rendering
+            // Should show error placeholder, not crash
             expect(result.frame.children.length).toBe(1);
-            expect(result.frame.children[0].type).toBe('TEXT');
+            expect(result.frame.children[0].type).toBe('FRAME');
         });
 
         it('should render normally when componentBindings is empty', async () => {
@@ -1225,6 +1322,170 @@ describe('renderBlocks', () => {
             const result = await renderBlocks('test', blocks, DEFAULT_SETTINGS);
             expect(result.frame.children.length).toBe(1);
             expect(result.frame.children[0].type).toBe('TEXT');
+        });
+
+        it('should call getNodeByIdAsync only once for repeated component bindings in same batch', async () => {
+            const contentLayer1 = makeMockTextLayer('#content');
+            const contentLayer2 = makeMockTextLayer('#content');
+            let callCount = 0;
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Shared Component',
+                createInstance: jest.fn(() => {
+                    callCount++;
+                    const layer = callCount === 1 ? contentLayer1 : contentLayer2;
+                    return {
+                        type: 'INSTANCE',
+                        name: 'Shared Component',
+                        layoutAlign: 'MIN',
+                        children: [layer],
+                        remove: jest.fn(),
+                    };
+                }),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Quote one' },
+                { type: 'quote', content: 'Quote two' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-shared-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            // Cache should prevent duplicate lookups
+            expect(figma.getNodeByIdAsync).toHaveBeenCalledTimes(1);
+            expect(mockComponent.createInstance).toHaveBeenCalledTimes(2);
+            expect(contentLayer1.characters).toBe('Quote one');
+            expect(contentLayer2.characters).toBe('Quote two');
+        });
+
+        it('should populate table component with serialized row data', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const titleLayer = makeMockTextLayer('#title', 'Bold');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Table Component',
+                layoutAlign: 'MIN',
+                children: [titleLayer, contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Table Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                {
+                    type: 'table',
+                    header: [{ text: 'Name' }, { text: 'Age' }] as any,
+                    rows: [
+                        [{ text: 'Alice' }, { text: '30' }],
+                        [{ text: 'Bob' }, { text: '25' }],
+                    ] as any,
+                    align: [null, null],
+                },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { table: 'comp-table-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(titleLayer.characters).toBe('Name | Age');
+            expect(contentLayer.characters).toBe('Alice | 30\nBob | 25');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should populate image component with imageUrl as content', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const titleLayer = makeMockTextLayer('#title', 'Bold');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Image Component',
+                layoutAlign: 'MIN',
+                children: [titleLayer, contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Image Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                {
+                    type: 'image',
+                    imageUrl: 'https://example.com/photo.png',
+                    imageAlt: 'A photo',
+                },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { image: 'comp-image-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(titleLayer.characters).toBe('A photo');
+            expect(contentLayer.characters).toBe('https://example.com/photo.png');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should set content to empty string when block.content is undefined', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Quote Component',
+                layoutAlign: 'MIN',
+                children: [contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Quote Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: undefined },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-undef-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(contentLayer.characters).toBe('');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should set layoutAlign to STRETCH on component instance', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Stretch Test',
+                layoutAlign: 'MIN',
+                children: [contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Stretch Test',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'stretch test' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-stretch-1' },
+            };
+            await renderBlocks('test', blocks, settings);
+            expect(mockInstance.layoutAlign).toBe('STRETCH');
         });
     });
 });

--- a/figma-markdown-sync/renderer.test.ts
+++ b/figma-markdown-sync/renderer.test.ts
@@ -1046,6 +1046,178 @@ describe('renderBlocks', () => {
             expect(result.frame.children[0]).toBe(mockInstance);
         });
 
+        it('should populate #title layer from calloutType', async () => {
+            const contentLayer = {
+                type: 'TEXT',
+                name: '#content',
+                characters: '',
+                fontName: { family: 'Inter', style: 'Regular' },
+                fontSize: 16,
+                fills: [],
+                layoutAlign: 'MIN',
+                layoutGrow: 0,
+                textAlignHorizontal: 'LEFT',
+                paragraphIndent: 0,
+                opacity: 1,
+                parent: null,
+                setRangeFontName: jest.fn(),
+                setRangeTextDecoration: jest.fn(),
+                setRangeHyperlink: jest.fn(),
+                setRangeFills: jest.fn(),
+                insertCharacters: jest.fn(),
+                remove: jest.fn(),
+                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
+            };
+            const titleLayer = {
+                type: 'TEXT',
+                name: '#title',
+                characters: '',
+                fontName: { family: 'Inter', style: 'Bold' },
+                fontSize: 14,
+                fills: [],
+                layoutAlign: 'MIN',
+                layoutGrow: 0,
+                textAlignHorizontal: 'LEFT',
+                paragraphIndent: 0,
+                opacity: 1,
+                parent: null,
+                setRangeFontName: jest.fn(),
+                setRangeTextDecoration: jest.fn(),
+                setRangeHyperlink: jest.fn(),
+                setRangeFills: jest.fn(),
+                insertCharacters: jest.fn(),
+                remove: jest.fn(),
+                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
+            };
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Callout Component',
+                layoutAlign: 'MIN',
+                children: [titleLayer, contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Callout Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'callout', calloutType: 'warning', content: 'Be careful!' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { callout: 'comp-callout-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(mockComponent.createInstance).toHaveBeenCalled();
+            expect(titleLayer.characters).toBe('warning');
+            expect(contentLayer.characters).toBe('Be careful!');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should use applyInlineStyles when block has tokens in component mode', async () => {
+            const contentLayer = {
+                type: 'TEXT',
+                name: '#content',
+                characters: '',
+                fontName: { family: 'Inter', style: 'Regular' },
+                fontSize: 16,
+                fills: [],
+                layoutAlign: 'MIN',
+                layoutGrow: 0,
+                textAlignHorizontal: 'LEFT',
+                paragraphIndent: 0,
+                opacity: 1,
+                parent: null,
+                setRangeFontName: jest.fn(),
+                setRangeTextDecoration: jest.fn(),
+                setRangeHyperlink: jest.fn(),
+                setRangeFills: jest.fn(),
+                insertCharacters: jest.fn(),
+                remove: jest.fn(),
+                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
+            };
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Quote Component',
+                layoutAlign: 'MIN',
+                children: [contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Quote Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                {
+                    type: 'quote',
+                    content: 'bold text',
+                    tokens: [
+                        { type: 'strong', raw: '**bold text**', text: 'bold text', tokens: [
+                            { type: 'text', raw: 'bold text', text: 'bold text' },
+                        ] } as any,
+                    ],
+                },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-quote-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(mockComponent.createInstance).toHaveBeenCalled();
+            // When tokens are present, applyInlineStyles sets .characters from flattened
+            // token text and calls setRangeFontName for formatting ranges
+            expect(contentLayer.characters).toBe('bold text');
+            expect(contentLayer.setRangeFontName).toHaveBeenCalled();
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should fall back when component node type is FRAME instead of COMPONENT', async () => {
+            const mockFrameNode = {
+                type: 'FRAME',
+                name: 'Not A Component',
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockFrameNode);
+
+            const blocks: Block[] = [
+                { type: 'code', content: 'let x = 1;', language: 'js' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { codeBlock: 'frame-id-999' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            // Should fall back to default code frame rendering
+            expect(result.frame.children.length).toBe(1);
+            expect(result.frame.children[0].type).toBe('FRAME');
+        });
+
+        it('should return null and fall back when createInstance throws', async () => {
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Broken Component',
+                createInstance: jest.fn(() => { throw new Error('Instance creation failed'); }),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Should still render' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-broken-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            // Should not crash — falls back to default rendering
+            expect(result.frame.children.length).toBe(1);
+            expect(result.frame.children[0].type).toBe('TEXT');
+        });
+
         it('should render normally when componentBindings is empty', async () => {
             const blocks: Block[] = [
                 { type: 'quote', content: 'Normal quote' },

--- a/figma-markdown-sync/renderer.test.ts
+++ b/figma-markdown-sync/renderer.test.ts
@@ -1461,6 +1461,48 @@ describe('renderBlocks', () => {
             expect(result.frame.children[0]).toBe(mockInstance);
         });
 
+        it('should clean up instance when font loading fails', async () => {
+            const contentLayer = makeMockTextLayer('#content');
+            // Use an unusual font that will trigger the loadFontAsync call in tryRenderWithComponent
+            contentLayer.fontName = { family: 'MissingFont', style: 'Regular' };
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'Font Fail Component',
+                layoutAlign: 'MIN',
+                children: [contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'Font Fail Component',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+            // Reject only for the specific font used by the content layer
+            const originalLoadFont = (figma.loadFontAsync as jest.Mock).getMockImplementation() || (() => Promise.resolve(undefined));
+            (figma.loadFontAsync as jest.Mock).mockImplementation((font: any) => {
+                if (font.family === 'MissingFont') return Promise.reject(new Error('Font not found'));
+                return Promise.resolve(undefined);
+            });
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Should fail on font' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-fontfail-1' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            // Instance should be cleaned up
+            expect(mockInstance.remove).toHaveBeenCalled();
+            // Should show error placeholder
+            expect(result.frame.children.length).toBe(1);
+            expect(result.frame.children[0].type).toBe('FRAME');
+
+            // Restore original mock
+            (figma.loadFontAsync as jest.Mock).mockImplementation(() => Promise.resolve(undefined));
+        });
+
         it('should set layoutAlign to STRETCH on component instance', async () => {
             const contentLayer = makeMockTextLayer('#content');
             const mockInstance = {

--- a/figma-markdown-sync/renderer.test.ts
+++ b/figma-markdown-sync/renderer.test.ts
@@ -949,4 +949,110 @@ describe('renderBlocks', () => {
             expect(listGroup.children[1].name).toBe('List/Unordered — Item 2');
         });
     });
+
+    describe('component output mode', () => {
+        it('should fall back to default rendering when component binding points to non-existent node', async () => {
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(null);
+            const blocks: Block[] = [
+                { type: 'code', content: 'console.log("hi")', language: 'js' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { codeBlock: 'nonexistent-id' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            expect(result.frame.children.length).toBe(1);
+            // Should render as normal code frame, not crash
+            expect(result.frame.children[0].type).toBe('FRAME');
+        });
+
+        it('should fall back when component has no #content layer', async () => {
+            // Mock a component node whose instance has no #content layer
+            const mockInstance = {
+                type: 'INSTANCE',
+                layoutAlign: 'MIN',
+                children: [
+                    { type: 'RECTANGLE', name: 'background', children: undefined },
+                ],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'My Code Block',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'code', content: 'hello', language: 'py' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { codeBlock: 'comp-123' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            // Should fall back and render as normal code frame
+            expect(mockInstance.remove).toHaveBeenCalled();
+            expect(result.frame.children[0].type).toBe('FRAME');
+        });
+
+        it('should use component instance when #content layer exists', async () => {
+            const contentLayer = {
+                type: 'TEXT',
+                name: '#content',
+                characters: '',
+                fontName: { family: 'Inter', style: 'Regular' },
+                fontSize: 16,
+                fills: [],
+                layoutAlign: 'MIN',
+                layoutGrow: 0,
+                textAlignHorizontal: 'LEFT',
+                paragraphIndent: 0,
+                opacity: 1,
+                parent: null,
+                setRangeFontName: jest.fn(),
+                setRangeTextDecoration: jest.fn(),
+                setRangeHyperlink: jest.fn(),
+                setRangeFills: jest.fn(),
+                insertCharacters: jest.fn(),
+                remove: jest.fn(),
+                setTextStyleIdAsync: jest.fn().mockResolvedValue(undefined),
+            };
+            const mockInstance = {
+                type: 'INSTANCE',
+                name: 'My Code Block',
+                layoutAlign: 'MIN',
+                children: [contentLayer],
+                remove: jest.fn(),
+            };
+            const mockComponent = {
+                type: 'COMPONENT',
+                name: 'My Code Block',
+                createInstance: jest.fn(() => mockInstance),
+            };
+            (figma.getNodeByIdAsync as jest.Mock).mockResolvedValue(mockComponent);
+
+            const blocks: Block[] = [
+                { type: 'quote', content: 'A wise saying' },
+            ];
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                componentBindings: { blockquote: 'comp-456' },
+            };
+            const result = await renderBlocks('test', blocks, settings);
+            // Should use the component instance
+            expect(mockComponent.createInstance).toHaveBeenCalled();
+            expect(contentLayer.characters).toBe('A wise saying');
+            expect(result.frame.children[0]).toBe(mockInstance);
+        });
+
+        it('should render normally when componentBindings is empty', async () => {
+            const blocks: Block[] = [
+                { type: 'quote', content: 'Normal quote' },
+            ];
+            const result = await renderBlocks('test', blocks, DEFAULT_SETTINGS);
+            expect(result.frame.children.length).toBe(1);
+            expect(result.frame.children[0].type).toBe('TEXT');
+        });
+    });
 });

--- a/figma-markdown-sync/renderer.ts
+++ b/figma-markdown-sync/renderer.ts
@@ -328,7 +328,8 @@ const COMPONENT_BINDING_MAP: Partial<Record<Block['type'], {
  * List-like blocks (list, orderedListItem, taskListItem) are handled by the
  * list grouping loop in renderBlocks and dispatched to dedicated render functions.
  * Throws on unrecoverable errors so the caller can insert an error placeholder.
- * Returns null for unrecognized block types (default branch) — the caller silently skips null returns.
+ * Returns null only for list-type blocks that reach here due to a routing bug.
+ * Unrecognized block types produce a visible error placeholder.
  */
 async function renderBlock(block: Block, settings: PluginSettings): Promise<SceneNode | null> {
     // Try Component Output Mode for supported block types
@@ -436,10 +437,9 @@ async function renderBlock(block: Block, settings: PluginSettings): Promise<Scen
         case 'list':
         case 'orderedListItem':
         case 'taskListItem':
-            // These are handled by the list grouping loop in renderBlocks — reaching
-            // here indicates a routing bug.
-            console.error(`[MarkDown For What] Block type "${block.type}" reached renderBlock — should be handled by list grouping`);
-            return null;
+            // Reaching here indicates a routing bug — list types should be handled
+            // by the list grouping loop in renderBlocks.
+            throw new Error(`Block type "${block.type}" reached renderBlock — should be handled by list grouping (routing bug)`);
 
         default:
             console.warn(`[MarkDown For What] Unknown block type: "${(block as { type: string }).type}" — skipping`);

--- a/figma-markdown-sync/renderer.ts
+++ b/figma-markdown-sync/renderer.ts
@@ -5,12 +5,13 @@
  *
  * This module owns the top-level rendering pipeline:
  *   - Frame creation and placement
+ *   - Component Output Mode dispatch
  *   - Block dispatch routing
  *   - List grouping into nested frames
  *   - Text style application
  *
  * Individual block renderers (callout, TOC, list, task, image, error placeholder)
- * live in blockRenderers.ts.
+ * and `tryRenderWithComponent` live in blockRenderers.ts.
  * Rendering constants (colors, bullets, checkbox paints) live in constants.ts.
  *
  * Public API:
@@ -299,11 +300,14 @@ export async function renderBlocks(
 
 /**
  * Renders a single non-list block into a SceneNode.
+ * Component Output Mode is attempted first for supported block types (via
+ * tryRenderWithComponent) before falling back to switch-based default rendering.
  * List-like blocks (list, orderedListItem, taskListItem) are handled by the
  * list grouping loop in renderBlocks and dispatched to dedicated render functions.
  * Throws on unrecoverable errors so the caller can insert an error placeholder.
  * Returns null for unrecognized block types (default branch) — the caller silently skips null returns.
  */
+
 /** Maps block types to their Component Output Mode binding key and title extractor. */
 const COMPONENT_BINDING_MAP: Partial<Record<Block['type'], { key: keyof ComponentBindings; title?: (b: Block) => string | undefined }>> = {
     quote:   { key: 'blockquote' },

--- a/figma-markdown-sync/renderer.ts
+++ b/figma-markdown-sync/renderer.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Block } from './parser';
-import type { PluginSettings, StyleBindings } from './settings';
+import type { PluginSettings, StyleBindings, ComponentBindings } from './settings';
 import { resolvedFrameWidth } from './settings';
 import { STYLE_NAMES, DEFAULT_STYLES, getOrCreateTextStyle, getOrCreateTextStyleWithBinding, applyInlineStyles, initializeStyles } from './styles';
 
@@ -304,9 +304,22 @@ export async function renderBlocks(
  * Throws on unrecoverable errors so the caller can insert an error placeholder.
  * Returns null for unrecognized block types (default branch) — the caller silently skips null returns.
  */
+/** Maps block types to their Component Output Mode binding key and title extractor. */
+const COMPONENT_BINDING_MAP: Partial<Record<Block['type'], { key: keyof ComponentBindings; title?: (b: Block) => string | undefined }>> = {
+    quote:   { key: 'blockquote' },
+    code:    { key: 'codeBlock', title: b => b.language || undefined },
+    table:   { key: 'table' },
+    image:   { key: 'image', title: b => b.imageAlt || undefined },
+    callout: { key: 'callout', title: b => b.calloutType ?? 'note' },
+};
+
 async function renderBlock(block: Block, settings: PluginSettings): Promise<SceneNode | null> {
     // Try Component Output Mode for supported block types
-    const cb = settings.componentBindings;
+    const mapping = COMPONENT_BINDING_MAP[block.type];
+    if (mapping) {
+        const compNode = await tryRenderWithComponent(block, mapping.key, settings.componentBindings, mapping.title?.(block));
+        if (compNode) return compNode;
+    }
 
     switch (block.type) {
         case 'heading': {
@@ -326,18 +339,12 @@ async function renderBlock(block: Block, settings: PluginSettings): Promise<Scen
         }
 
         case 'quote': {
-            const compNode = await tryRenderWithComponent(block, 'blockquote', cb);
-            if (compNode) return compNode;
-
             const node = figma.createText();
             await applyTextStyle(node, block, STYLE_NAMES.QUOTE, settings.styleBindings);
             return node;
         }
 
         case 'code': {
-            const compNode = await tryRenderWithComponent(block, 'codeBlock', cb, block.language || undefined);
-            if (compNode) return compNode;
-
             const codeFrame = figma.createFrame();
             codeFrame.layoutMode = 'VERTICAL';
             codeFrame.primaryAxisSizingMode = 'AUTO';
@@ -370,23 +377,14 @@ async function renderBlock(block: Block, settings: PluginSettings): Promise<Scen
         }
 
         case 'table': {
-            const compNode = await tryRenderWithComponent(block, 'table', cb);
-            if (compNode) return compNode;
-
             return await createTableFrame(block, settings);
         }
 
         case 'image': {
-            const compNode = await tryRenderWithComponent(block, 'image', cb, block.imageAlt || undefined);
-            if (compNode) return compNode;
-
             return await createImageNode(block, settings);
         }
 
         case 'callout': {
-            const compNode = await tryRenderWithComponent(block, 'callout', cb, block.calloutType ?? 'note');
-            if (compNode) return compNode;
-
             return await renderCalloutBlock(block);
         }
 

--- a/figma-markdown-sync/renderer.ts
+++ b/figma-markdown-sync/renderer.ts
@@ -47,6 +47,7 @@ import {
     renderMathBlock,
     createImageNode,
     createErrorPlaceholder,
+    tryRenderWithComponent,
 } from './blockRenderers';
 
 /** Result returned by renderBlocks with the rendered frame and non-fatal warning counts. */
@@ -304,6 +305,9 @@ export async function renderBlocks(
  * Returns null for unrecognized block types (default branch) — the caller silently skips null returns.
  */
 async function renderBlock(block: Block, settings: PluginSettings): Promise<SceneNode | null> {
+    // Try Component Output Mode for supported block types
+    const cb = settings.componentBindings;
+
     switch (block.type) {
         case 'heading': {
             const node = figma.createText();
@@ -322,12 +326,18 @@ async function renderBlock(block: Block, settings: PluginSettings): Promise<Scen
         }
 
         case 'quote': {
+            const compNode = await tryRenderWithComponent(block, 'blockquote', cb);
+            if (compNode) return compNode;
+
             const node = figma.createText();
             await applyTextStyle(node, block, STYLE_NAMES.QUOTE, settings.styleBindings);
             return node;
         }
 
         case 'code': {
+            const compNode = await tryRenderWithComponent(block, 'codeBlock', cb, block.language || undefined);
+            if (compNode) return compNode;
+
             const codeFrame = figma.createFrame();
             codeFrame.layoutMode = 'VERTICAL';
             codeFrame.primaryAxisSizingMode = 'AUTO';
@@ -360,14 +370,23 @@ async function renderBlock(block: Block, settings: PluginSettings): Promise<Scen
         }
 
         case 'table': {
+            const compNode = await tryRenderWithComponent(block, 'table', cb);
+            if (compNode) return compNode;
+
             return await createTableFrame(block, settings);
         }
 
         case 'image': {
+            const compNode = await tryRenderWithComponent(block, 'image', cb, block.imageAlt || undefined);
+            if (compNode) return compNode;
+
             return await createImageNode(block, settings);
         }
 
         case 'callout': {
+            const compNode = await tryRenderWithComponent(block, 'callout', cb, block.calloutType ?? 'note');
+            if (compNode) return compNode;
+
             return await renderCalloutBlock(block);
         }
 

--- a/figma-markdown-sync/renderer.ts
+++ b/figma-markdown-sync/renderer.ts
@@ -10,8 +10,7 @@
  *   - List grouping into nested frames
  *   - Text style application
  *
- * Individual block renderers (callout, TOC, list, task, image, error placeholder)
- * and `tryRenderWithComponent` live in blockRenderers.ts.
+ * Individual block renderers and `tryRenderWithComponent` live in blockRenderers.ts.
  * Rendering constants (colors, bullets, checkbox paints) live in constants.ts.
  *
  * Public API:
@@ -49,6 +48,7 @@ import {
     createImageNode,
     createErrorPlaceholder,
     tryRenderWithComponent,
+    clearComponentCache,
 } from './blockRenderers';
 
 /** Result returned by renderBlocks with the rendered frame and non-fatal warning counts. */
@@ -174,6 +174,9 @@ export async function renderBlocks(
     settings: PluginSettings,
     targetNode?: SceneNode
 ): Promise<RenderResult> {
+    // Clear per-render component cache so stale lookups don't persist across batches
+    clearComponentCache();
+
     // Ensure all Markdown/* text styles exist
     try {
         await initializeStyles();
@@ -185,7 +188,7 @@ export async function renderBlocks(
     // to figma.currentPage.children, which would inflate computeNewFrameX's result.
     const newFrameX = (!targetNode || !targetNode.parent) ? computeNewFrameX(100) : 0;
 
-    // ── Create outer frame (do NOT insert into document yet) ─────────────────
+    // ── Create outer frame (auto-appended by Figma; final placement is set after rendering) ──
     const frame = figma.createFrame();
 
     frame.name = name;
@@ -298,6 +301,26 @@ export async function renderBlocks(
 
 // ─── Block-level render dispatch ─────────────────────────────────────────────
 
+/** Maps block types to their Component Output Mode binding key, title, and content extractors. */
+const COMPONENT_BINDING_MAP: Partial<Record<Block['type'], {
+    key: keyof ComponentBindings;
+    title?: (b: Block) => string | undefined;
+    content?: (b: Block) => string;
+}>> = {
+    quote:   { key: 'blockquote' },
+    code:    { key: 'codeBlock', title: b => b.language || undefined },
+    table:   {
+        key: 'table',
+        title: b => b.header?.map(c => c.text).join(' | ') || undefined,
+        content: b => {
+            const rows = b.rows?.map(r => r.map(c => c.text).join(' | ')) ?? [];
+            return rows.join('\n');
+        },
+    },
+    image:   { key: 'image', title: b => b.imageAlt || undefined, content: b => b.imageUrl ?? '' },
+    callout: { key: 'callout', title: b => b.calloutType ?? 'note' },
+};
+
 /**
  * Renders a single non-list block into a SceneNode.
  * Component Output Mode is attempted first for supported block types (via
@@ -307,21 +330,15 @@ export async function renderBlocks(
  * Throws on unrecoverable errors so the caller can insert an error placeholder.
  * Returns null for unrecognized block types (default branch) — the caller silently skips null returns.
  */
-
-/** Maps block types to their Component Output Mode binding key and title extractor. */
-const COMPONENT_BINDING_MAP: Partial<Record<Block['type'], { key: keyof ComponentBindings; title?: (b: Block) => string | undefined }>> = {
-    quote:   { key: 'blockquote' },
-    code:    { key: 'codeBlock', title: b => b.language || undefined },
-    table:   { key: 'table' },
-    image:   { key: 'image', title: b => b.imageAlt || undefined },
-    callout: { key: 'callout', title: b => b.calloutType ?? 'note' },
-};
-
 async function renderBlock(block: Block, settings: PluginSettings): Promise<SceneNode | null> {
     // Try Component Output Mode for supported block types
     const mapping = COMPONENT_BINDING_MAP[block.type];
     if (mapping) {
-        const compNode = await tryRenderWithComponent(block, mapping.key, settings.componentBindings, mapping.title?.(block));
+        // Override block content if the mapping provides a custom content extractor
+        const blockForComponent = mapping.content
+            ? { ...block, content: mapping.content(block), tokens: undefined }
+            : block;
+        const compNode = await tryRenderWithComponent(blockForComponent, mapping.key, settings.componentBindings, mapping.title?.(block));
         if (compNode) return compNode;
     }
 
@@ -426,7 +443,7 @@ async function renderBlock(block: Block, settings: PluginSettings): Promise<Scen
 
         default:
             console.warn(`[MarkDown For What] Unknown block type: "${(block as { type: string }).type}" — skipping`);
-            return null;
+            return await createErrorPlaceholder(block, `Unknown block type: "${(block as { type: string }).type}"`);
     }
 }
 

--- a/figma-markdown-sync/settings.test.ts
+++ b/figma-markdown-sync/settings.test.ts
@@ -458,6 +458,11 @@ describe('componentBindings', () => {
         expect(validateSettings(settings)).toBe(false);
     });
 
+    test('rejects empty-string componentBindings values', () => {
+        const settings = { ...DEFAULT_SETTINGS, componentBindings: { codeBlock: '' } };
+        expect(validateSettings(settings)).toBe(false);
+    });
+
     test('mergeWithDefaults preserves valid componentBindings', () => {
         const partial = { ...DEFAULT_SETTINGS, componentBindings: { blockquote: 'comp-789' } };
         const merged = mergeWithDefaults(partial);

--- a/figma-markdown-sync/settings.test.ts
+++ b/figma-markdown-sync/settings.test.ts
@@ -126,6 +126,7 @@ describe('mergeWithDefaults', () => {
             frameFillColor: '#F0F0F0',
             styleBindings: { h1: 'S:abc123' },
             componentNames: false,
+            componentBindings: {},
         };
         const result = mergeWithDefaults(custom);
         expect(result).toEqual(custom);
@@ -430,5 +431,48 @@ describe('import history', () => {
         (figma.clientStorage.getAsync as jest.Mock).mockRejectedValue(new Error('storage error'));
         const history = await loadHistory();
         expect(history).toEqual([]);
+    });
+});
+
+describe('componentBindings', () => {
+    test('DEFAULT_SETTINGS has empty componentBindings', () => {
+        expect(DEFAULT_SETTINGS.componentBindings).toEqual({});
+    });
+
+    test('validates settings with empty componentBindings', () => {
+        expect(validateSettings(DEFAULT_SETTINGS)).toBe(true);
+    });
+
+    test('validates settings with populated componentBindings', () => {
+        const settings = { ...DEFAULT_SETTINGS, componentBindings: { codeBlock: 'comp-123', callout: 'comp-456' } };
+        expect(validateSettings(settings)).toBe(true);
+    });
+
+    test('rejects invalid componentBindings keys', () => {
+        const settings = { ...DEFAULT_SETTINGS, componentBindings: { unknownKey: 'comp-123' } };
+        expect(validateSettings(settings)).toBe(false);
+    });
+
+    test('rejects non-string componentBindings values', () => {
+        const settings = { ...DEFAULT_SETTINGS, componentBindings: { codeBlock: 123 } };
+        expect(validateSettings(settings)).toBe(false);
+    });
+
+    test('mergeWithDefaults preserves valid componentBindings', () => {
+        const partial = { ...DEFAULT_SETTINGS, componentBindings: { blockquote: 'comp-789' } };
+        const merged = mergeWithDefaults(partial);
+        expect(merged.componentBindings).toEqual({ blockquote: 'comp-789' });
+    });
+
+    test('mergeWithDefaults fills missing componentBindings with empty object', () => {
+        const { componentBindings, ...rest } = DEFAULT_SETTINGS;
+        const merged = mergeWithDefaults(rest);
+        expect(merged.componentBindings).toEqual({});
+    });
+
+    test('mergeWithDefaults replaces invalid componentBindings with empty object', () => {
+        const partial = { ...DEFAULT_SETTINGS, componentBindings: 'not-an-object' };
+        const merged = mergeWithDefaults(partial);
+        expect(merged.componentBindings).toEqual({});
     });
 });

--- a/figma-markdown-sync/settings.ts
+++ b/figma-markdown-sync/settings.ts
@@ -13,7 +13,6 @@
  *   loadSettings()                — async: reads from clientStorage, merges with defaults
  *   saveSettings(settings)        — async: writes to clientStorage
  *   ComponentBindings             — type for component output mode bindings
- *   isValidComponentBindings(obj) — returns true if obj is a valid ComponentBindings
  */
 
 import { isValidHex } from './utils';
@@ -161,14 +160,11 @@ export async function recordImport(filename: string, blockCount: number): Promis
 }
 
 /**
- * Clears all import history.
+ * Clears all import history. Throws on storage failure so callers can
+ * report the error to the user rather than showing a false success message.
  */
 export async function clearHistory(): Promise<void> {
-    try {
-        await figma.clientStorage.setAsync(HISTORY_STORAGE_KEY, []);
-    } catch (err) {
-        console.error('[MarkDown For What] Failed to clear import history:', err);
-    }
+    await figma.clientStorage.setAsync(HISTORY_STORAGE_KEY, []);
 }
 
 // ─── Theme Presets ──────────────────────────────────────────────────────────────
@@ -255,16 +251,16 @@ function isPositiveNumber(value: unknown): boolean {
 }
 
 const VALID_BINDING_KEYS = ['h1', 'h2', 'h3', 'body', 'code', 'list', 'quote', 'codeBg', 'tableBg'];
-const VALID_COMPONENT_BINDING_KEYS = ['codeBlock', 'blockquote', 'callout', 'table', 'image'];
+const VALID_COMPONENT_BINDING_KEYS: (keyof ComponentBindings)[] = ['codeBlock', 'blockquote', 'callout', 'table', 'image'];
 
-/** Returns true if value is a plain object whose keys are in validKeys and whose values are strings. */
+/** Returns true if value is a plain object whose keys are in validKeys and whose values are non-empty strings. */
 function isValidBindings(value: unknown, validKeys: string[]): boolean {
     if (value === undefined || value === null) return false;
     if (typeof value !== 'object' || Array.isArray(value)) return false;
     const obj = value as Record<string, unknown>;
     for (const key of Object.keys(obj)) {
         if (!validKeys.includes(key)) return false;
-        if (typeof obj[key] !== 'string') return false;
+        if (typeof obj[key] !== 'string' || obj[key] === '') return false;
     }
     return true;
 }

--- a/figma-markdown-sync/settings.ts
+++ b/figma-markdown-sync/settings.ts
@@ -7,12 +7,12 @@
  * This module does NOT render anything. It only defines and manages data.
  *
  * Public API:
- *   DEFAULT_SETTINGS              — the baseline values used on first run
- *   validateSettings(obj)         — returns true if obj is a well-formed PluginSettings
- *   mergeWithDefaults(obj)        — fills missing/invalid fields with defaults
- *   loadSettings()                — async: reads from clientStorage, merges with defaults
- *   saveSettings(settings)        — async: writes to clientStorage
- *   ComponentBindings             — type for component output mode bindings
+ *   Types: PluginSettings, StyleBindings, ComponentBindings, WidthMode, Theme, ImportHistoryEntry
+ *   Constants: DEFAULT_SETTINGS, THEME_PRESETS, WIDTH_PRESETS
+ *   Validation: validateSettings(obj), mergeWithDefaults(obj), resolvedFrameWidth(settings)
+ *   Theme: resolveThemeSettings(theme)
+ *   Persistence: loadSettings(), saveSettings(settings)
+ *   History: loadHistory(), recordImport(filename, blockCount), clearHistory()
  */
 
 import { isValidHex } from './utils';
@@ -144,13 +144,20 @@ export async function loadHistory(): Promise<ImportHistoryEntry[]> {
 /**
  * Records a new import in history.
  * Prepends to the list, deduplicates by filename (keeps latest), and trims to MAX_HISTORY_ENTRIES.
+ * If history cannot be read, the write is skipped to avoid overwriting existing entries with
+ * a single-item array (cascading silent-fallback data loss).
  */
 export async function recordImport(filename: string, blockCount: number): Promise<void> {
-    const history = await loadHistory();
+    let history: ImportHistoryEntry[];
+    try {
+        const raw = await figma.clientStorage.getAsync(HISTORY_STORAGE_KEY);
+        history = Array.isArray(raw) ? raw.slice(0, MAX_HISTORY_ENTRIES) : [];
+    } catch (err) {
+        console.error('[MarkDown For What] Cannot read history; skipping record to avoid data loss:', err);
+        return;
+    }
     const entry: ImportHistoryEntry = { filename, timestamp: Date.now(), blockCount };
-    // Remove any existing entry with the same filename
     const filtered = history.filter(h => h.filename !== filename);
-    // Prepend new entry and trim
     const updated = [entry, ...filtered].slice(0, MAX_HISTORY_ENTRIES);
     try {
         await figma.clientStorage.setAsync(HISTORY_STORAGE_KEY, updated);
@@ -200,10 +207,10 @@ export const THEME_PRESETS: Record<Exclude<Theme, 'custom'>, Partial<PluginSetti
     },
 };
 
-const VALID_THEMES: readonly string[] = ['minimal-light', 'dark-mode', 'documentation', 'custom'];
+const VALID_THEMES: readonly Theme[] = ['minimal-light', 'dark-mode', 'documentation', 'custom'];
 
 function isValidTheme(value: unknown): value is Theme {
-    return typeof value === 'string' && VALID_THEMES.includes(value);
+    return typeof value === 'string' && VALID_THEMES.includes(value as Theme);
 }
 
 /**
@@ -224,10 +231,10 @@ export const WIDTH_PRESETS: Record<WidthMode, number | null> = {
     custom: null,
 };
 
-const VALID_WIDTH_MODES: readonly string[] = Object.keys(WIDTH_PRESETS);
+const VALID_WIDTH_MODES: readonly WidthMode[] = Object.keys(WIDTH_PRESETS) as WidthMode[];
 
 function isValidWidthMode(value: unknown): value is WidthMode {
-    return typeof value === 'string' && VALID_WIDTH_MODES.includes(value);
+    return typeof value === 'string' && VALID_WIDTH_MODES.includes(value as WidthMode);
 }
 
 /**
@@ -271,6 +278,17 @@ function isValidStyleBindings(value: unknown): boolean {
 
 function isValidComponentBindings(value: unknown): boolean {
     return isValidBindings(value, VALID_COMPONENT_BINDING_KEYS);
+}
+
+/** Strips empty-string values from a bindings object so legacy stored data doesn't fail validation. */
+function sanitizeBindings(value: unknown): unknown {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+    const obj = value as Record<string, unknown>;
+    const cleaned: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+        if (v !== '') cleaned[k] = v;
+    }
+    return cleaned;
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────────
@@ -352,9 +370,9 @@ export function mergeWithDefaults(partial: unknown): PluginSettings {
         generateToc:           typeof p.generateToc === 'boolean'     ? p.generateToc                       : DEFAULT_SETTINGS.generateToc,
         theme:                 isValidTheme(p.theme)                  ? p.theme                              : DEFAULT_SETTINGS.theme,
         frameFillColor:        isValidHex(p.frameFillColor)           ? (p.frameFillColor as string)        : DEFAULT_SETTINGS.frameFillColor,
-        styleBindings:         isValidStyleBindings(p.styleBindings)  ? (p.styleBindings as StyleBindings)  : { ...DEFAULT_SETTINGS.styleBindings },
+        styleBindings:         isValidStyleBindings(sanitizeBindings(p.styleBindings))  ? (sanitizeBindings(p.styleBindings) as StyleBindings)  : { ...DEFAULT_SETTINGS.styleBindings },
         componentNames:        typeof p.componentNames === 'boolean'   ? p.componentNames                     : DEFAULT_SETTINGS.componentNames,
-        componentBindings:     isValidComponentBindings(p.componentBindings) ? (p.componentBindings as ComponentBindings) : { ...DEFAULT_SETTINGS.componentBindings },
+        componentBindings:     isValidComponentBindings(sanitizeBindings(p.componentBindings)) ? (sanitizeBindings(p.componentBindings) as ComponentBindings) : { ...DEFAULT_SETTINGS.componentBindings },
     };
     // Keep frameWidth in sync with resolved width for backwards compat
     merged.frameWidth = resolvedFrameWidth(merged);
@@ -372,7 +390,7 @@ export async function loadSettings(): Promise<PluginSettings> {
         const raw = await figma.clientStorage.getAsync(STORAGE_KEY);
         return mergeWithDefaults(raw);
     } catch (err) {
-        console.error('[MarkDown For What] Failed to load settings:', err);
+        console.error('[MarkDown For What] Failed to load settings — using defaults:', err);
         return { ...DEFAULT_SETTINGS };
     }
 }

--- a/figma-markdown-sync/settings.ts
+++ b/figma-markdown-sync/settings.ts
@@ -7,11 +7,13 @@
  * This module does NOT render anything. It only defines and manages data.
  *
  * Public API:
- *   DEFAULT_SETTINGS          — the baseline values used on first run
- *   validateSettings(obj)     — returns true if obj is a well-formed PluginSettings
- *   mergeWithDefaults(obj)    — fills missing/invalid fields with defaults
- *   loadSettings()            — async: reads from clientStorage, merges with defaults
- *   saveSettings(settings)    — async: writes to clientStorage
+ *   DEFAULT_SETTINGS              — the baseline values used on first run
+ *   validateSettings(obj)         — returns true if obj is a well-formed PluginSettings
+ *   mergeWithDefaults(obj)        — fills missing/invalid fields with defaults
+ *   loadSettings()                — async: reads from clientStorage, merges with defaults
+ *   saveSettings(settings)        — async: writes to clientStorage
+ *   ComponentBindings             — type for component output mode bindings
+ *   isValidComponentBindings(obj) — returns true if obj is a valid ComponentBindings
  */
 
 import { isValidHex } from './utils';
@@ -77,7 +79,7 @@ export interface StyleBindings {
 /**
  * Maps block types to Figma component IDs for Component Output Mode.
  * When a binding is set, the renderer creates an instance of the component
- * and populates #content/#title text layers instead of building from scratch.
+ * and populates `#content` (or `#body`) / `#title` (or `#label`) text layers instead of building from scratch.
  */
 export interface ComponentBindings {
     codeBlock?: string;
@@ -134,7 +136,8 @@ export async function loadHistory(): Promise<ImportHistoryEntry[]> {
         const raw = await figma.clientStorage.getAsync(HISTORY_STORAGE_KEY);
         if (Array.isArray(raw)) return raw.slice(0, MAX_HISTORY_ENTRIES);
         return [];
-    } catch {
+    } catch (err) {
+        console.error('[MarkDown For What] Failed to load import history:', err);
         return [];
     }
 }

--- a/figma-markdown-sync/settings.ts
+++ b/figma-markdown-sync/settings.ts
@@ -250,7 +250,7 @@ function isPositiveNumber(value: unknown): boolean {
     return typeof value === 'number' && isFinite(value) && value > 0;
 }
 
-const VALID_BINDING_KEYS = ['h1', 'h2', 'h3', 'body', 'code', 'list', 'quote', 'codeBg', 'tableBg'];
+const VALID_BINDING_KEYS: (keyof StyleBindings)[] = ['h1', 'h2', 'h3', 'body', 'code', 'list', 'quote', 'codeBg', 'tableBg'];
 const VALID_COMPONENT_BINDING_KEYS: (keyof ComponentBindings)[] = ['codeBlock', 'blockquote', 'callout', 'table', 'image'];
 
 /** Returns true if value is a plain object whose keys are in validKeys and whose values are non-empty strings. */

--- a/figma-markdown-sync/settings.ts
+++ b/figma-markdown-sync/settings.ts
@@ -57,6 +57,8 @@ export interface PluginSettings {
     styleBindings: StyleBindings;
     /** When true, use semantic component-ready layer names (e.g. "Heading/H1", "Body/Paragraph"). */
     componentNames: boolean;
+    /** Mappings from block types to Figma component IDs for Component Output Mode. */
+    componentBindings: ComponentBindings;
 }
 
 /** Maps block element types to Figma style IDs. 'auto' or absent = use default Markdown/* styles. */
@@ -70,6 +72,19 @@ export interface StyleBindings {
     quote?: string;
     codeBg?: string;
     tableBg?: string;
+}
+
+/**
+ * Maps block types to Figma component IDs for Component Output Mode.
+ * When a binding is set, the renderer creates an instance of the component
+ * and populates #content/#title text layers instead of building from scratch.
+ */
+export interface ComponentBindings {
+    codeBlock?: string;
+    blockquote?: string;
+    callout?: string;
+    table?: string;
+    image?: string;
 }
 
 // ─── Defaults ──────────────────────────────────────────────────────────────────
@@ -92,6 +107,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     frameFillColor: '#FFFFFF',
     styleBindings: {},
     componentNames: false,
+    componentBindings: {},
 };
 
 const STORAGE_KEY = 'pluginSettings';
@@ -249,6 +265,20 @@ function isValidStyleBindings(value: unknown): boolean {
     return true;
 }
 
+const VALID_COMPONENT_BINDING_KEYS = ['codeBlock', 'blockquote', 'callout', 'table', 'image'];
+
+/** Returns true if value is a valid ComponentBindings object (plain object with string values). */
+function isValidComponentBindings(value: unknown): boolean {
+    if (value === undefined || value === null) return false;
+    if (typeof value !== 'object' || Array.isArray(value)) return false;
+    const obj = value as Record<string, unknown>;
+    for (const key of Object.keys(obj)) {
+        if (!VALID_COMPONENT_BINDING_KEYS.includes(key)) return false;
+        if (typeof obj[key] !== 'string') return false;
+    }
+    return true;
+}
+
 // ─── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -276,7 +306,8 @@ export function validateSettings(obj: unknown): obj is PluginSettings {
         isValidTheme(s.theme) &&
         isValidHex(s.frameFillColor) &&
         isValidStyleBindings(s.styleBindings) &&
-        typeof s.componentNames === 'boolean'
+        typeof s.componentNames === 'boolean' &&
+        isValidComponentBindings(s.componentBindings)
     );
 }
 
@@ -329,6 +360,7 @@ export function mergeWithDefaults(partial: unknown): PluginSettings {
         frameFillColor:        isValidHex(p.frameFillColor)           ? (p.frameFillColor as string)        : DEFAULT_SETTINGS.frameFillColor,
         styleBindings:         isValidStyleBindings(p.styleBindings)  ? (p.styleBindings as StyleBindings)  : { ...DEFAULT_SETTINGS.styleBindings },
         componentNames:        typeof p.componentNames === 'boolean'   ? p.componentNames                     : DEFAULT_SETTINGS.componentNames,
+        componentBindings:     isValidComponentBindings(p.componentBindings) ? (p.componentBindings as ComponentBindings) : { ...DEFAULT_SETTINGS.componentBindings },
     };
     // Keep frameWidth in sync with resolved width for backwards compat
     merged.frameWidth = resolvedFrameWidth(merged);

--- a/figma-markdown-sync/settings.ts
+++ b/figma-markdown-sync/settings.ts
@@ -252,31 +252,26 @@ function isPositiveNumber(value: unknown): boolean {
 }
 
 const VALID_BINDING_KEYS = ['h1', 'h2', 'h3', 'body', 'code', 'list', 'quote', 'codeBg', 'tableBg'];
+const VALID_COMPONENT_BINDING_KEYS = ['codeBlock', 'blockquote', 'callout', 'table', 'image'];
 
-/** Returns true if value is a valid StyleBindings object (plain object with string values). */
-function isValidStyleBindings(value: unknown): boolean {
+/** Returns true if value is a plain object whose keys are in validKeys and whose values are strings. */
+function isValidBindings(value: unknown, validKeys: string[]): boolean {
     if (value === undefined || value === null) return false;
     if (typeof value !== 'object' || Array.isArray(value)) return false;
     const obj = value as Record<string, unknown>;
     for (const key of Object.keys(obj)) {
-        if (!VALID_BINDING_KEYS.includes(key)) return false;
+        if (!validKeys.includes(key)) return false;
         if (typeof obj[key] !== 'string') return false;
     }
     return true;
 }
 
-const VALID_COMPONENT_BINDING_KEYS = ['codeBlock', 'blockquote', 'callout', 'table', 'image'];
+function isValidStyleBindings(value: unknown): boolean {
+    return isValidBindings(value, VALID_BINDING_KEYS);
+}
 
-/** Returns true if value is a valid ComponentBindings object (plain object with string values). */
 function isValidComponentBindings(value: unknown): boolean {
-    if (value === undefined || value === null) return false;
-    if (typeof value !== 'object' || Array.isArray(value)) return false;
-    const obj = value as Record<string, unknown>;
-    for (const key of Object.keys(obj)) {
-        if (!VALID_COMPONENT_BINDING_KEYS.includes(key)) return false;
-        if (typeof obj[key] !== 'string') return false;
-    }
-    return true;
+    return isValidBindings(value, VALID_COMPONENT_BINDING_KEYS);
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────────

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -68,7 +68,8 @@ const styleBindingSelects = document.querySelectorAll<HTMLSelectElement>('.style
 // Component binding selects
 const componentBindingSelects = document.querySelectorAll<HTMLSelectElement>('.component-binding-select');
 
-// Theme presets (duplicated from settings.ts — UI runs in a separate iframe bundle)
+// Theme presets (duplicated from settings.ts — UI runs in a separate iframe bundle).
+// IMPORTANT: Keep in sync with THEME_PRESETS in settings.ts.
 const THEME_PRESETS: Record<string, Record<string, unknown>> = {
     'minimal-light': {
         frameFillColor: '#FFFFFF', codeBackground: '#F2F2F2',
@@ -514,6 +515,7 @@ function sendCurrentSettings() {
     // Compute frameWidth from widthMode/customWidth for backwards compat with validateSettings.
     // Duplicated from settings.ts WIDTH_PRESETS — UI runs in a separate iframe bundle,
     // so it cannot import from the plugin sandbox bundle directly.
+    // IMPORTANT: Keep in sync with WIDTH_PRESETS in settings.ts (custom omitted; handled by fallback).
     const widthPresets: Record<string, number> = { narrow: 480, medium: 800, wide: 960 };
     const mode = settings.widthMode as string;
     settings.frameWidth = widthPresets[mode] ?? (settings.customWidth as number) ?? 800;

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -361,24 +361,33 @@ function populateSettings(settings: Record<string, unknown>) {
         btn.classList.toggle('active', btn.dataset.theme === theme);
     });
 
-    // Handle style bindings
-    const bindings = (settings.styleBindings ?? {}) as Record<string, string>;
-    styleBindingSelects.forEach(select => {
-        const key = select.dataset.binding;
-        if (key && bindings[key]) select.value = bindings[key];
-        else select.value = 'auto';
-    });
-
-    // Handle component bindings
-    const compBindings = (settings.componentBindings ?? {}) as Record<string, string>;
-    componentBindingSelects.forEach(select => {
-        const key = select.dataset.binding;
-        if (key && compBindings[key]) select.value = compBindings[key];
-        else select.value = '';
-    });
+    // Handle style and component bindings
+    restoreBindings(styleBindingSelects, (settings.styleBindings ?? {}) as Record<string, string>, 'auto');
+    restoreBindings(componentBindingSelects, (settings.componentBindings ?? {}) as Record<string, string>, '');
 
     // Handle width mode visibility
     updateCustomWidthVisibility();
+}
+
+/** Restores select values from a bindings record, falling back to defaultValue. */
+function restoreBindings(selects: NodeListOf<HTMLSelectElement>, bindings: Record<string, string>, defaultValue: string) {
+    selects.forEach(select => {
+        const key = select.dataset.binding;
+        if (key && bindings[key]) select.value = bindings[key];
+        else select.value = defaultValue;
+    });
+}
+
+/** Collects binding values from a set of <select> elements, omitting those set to defaultValue. */
+function collectBindings(selects: NodeListOf<HTMLSelectElement>, defaultValue: string): Record<string, string> {
+    const bindings: Record<string, string> = {};
+    selects.forEach(select => {
+        const key = select.dataset.binding;
+        if (key && select.value !== defaultValue) {
+            bindings[key] = select.value;
+        }
+    });
+    return bindings;
 }
 
 /** Populates a set of <select> dropdowns with items, preserving current selections. */
@@ -495,16 +504,6 @@ function sendCurrentSettings() {
     }
 
     // Collect style and component bindings
-    function collectBindings(selects: NodeListOf<HTMLSelectElement>, defaultValue: string): Record<string, string> {
-        const bindings: Record<string, string> = {};
-        selects.forEach(select => {
-            const key = select.dataset.binding;
-            if (key && select.value !== defaultValue) {
-                bindings[key] = select.value;
-            }
-        });
-        return bindings;
-    }
     settings.styleBindings = collectBindings(styleBindingSelects, 'auto');
     settings.componentBindings = collectBindings(componentBindingSelects, '');
 
@@ -595,9 +594,11 @@ window.onmessage = event => {
             break;
         case MSG_LOCAL_STYLES:
             populateDropdowns(styleBindingSelects, msg.textStyles ?? []);
+            if (msg.error) showStatus(msg.error, 'error');
             break;
         case MSG_LOCAL_COMPONENTS:
             populateDropdowns(componentBindingSelects, msg.components ?? []);
+            if (msg.error) showStatus(msg.error, 'error');
             break;
         case MSG_HISTORY:
             renderHistory(msg.entries ?? []);

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -59,6 +59,9 @@ const themeBtns = document.querySelectorAll<HTMLButtonElement>('.theme-btn');
 // Style binding selects
 const styleBindingSelects = document.querySelectorAll<HTMLSelectElement>('.style-binding-select');
 
+// Component binding selects
+const componentBindingSelects = document.querySelectorAll<HTMLSelectElement>('.component-binding-select');
+
 // Theme presets (duplicated from settings.ts — UI runs in a separate iframe bundle)
 const THEME_PRESETS: Record<string, Record<string, unknown>> = {
     'minimal-light': {
@@ -98,6 +101,7 @@ tabs.forEach(tab => {
         if (tab.dataset.tab === 'settings') {
             parent.postMessage({ pluginMessage: { type: 'get-settings' } }, '*');
             parent.postMessage({ pluginMessage: { type: 'get-local-styles' } }, '*');
+            parent.postMessage({ pluginMessage: { type: 'get-local-components' } }, '*');
         }
         if (tab.dataset.tab === 'history') {
             parent.postMessage({ pluginMessage: { type: 'get-history' } }, '*');
@@ -362,6 +366,14 @@ function populateSettings(settings: Record<string, unknown>) {
         else select.value = 'auto';
     });
 
+    // Handle component bindings
+    const compBindings = (settings.componentBindings ?? {}) as Record<string, string>;
+    componentBindingSelects.forEach(select => {
+        const key = select.dataset.binding;
+        if (key && compBindings[key]) select.value = compBindings[key];
+        else select.value = '';
+    });
+
     // Handle width mode visibility
     updateCustomWidthVisibility();
 }
@@ -376,6 +388,25 @@ function populateStyleDropdowns(textStyles: Array<{ id: string; name: string }>)
             const opt = document.createElement('option');
             opt.value = style.id;
             opt.textContent = style.name;
+            select.appendChild(opt);
+        }
+        // Restore previous selection if it still exists
+        if (currentValue && Array.from(select.options).some(o => o.value === currentValue)) {
+            select.value = currentValue;
+        }
+    });
+}
+
+function populateComponentDropdowns(components: Array<{ id: string; name: string }>) {
+    componentBindingSelects.forEach(select => {
+        const currentValue = select.value;
+        // Clear all options except "None"
+        while (select.options.length > 1) select.remove(1);
+        // Add each local component as an option
+        for (const comp of components) {
+            const opt = document.createElement('option');
+            opt.value = comp.id;
+            opt.textContent = comp.name;
             select.appendChild(opt);
         }
         // Restore previous selection if it still exists
@@ -453,6 +484,13 @@ function setupSettingListeners() {
         });
     });
 
+    // Component binding selects
+    componentBindingSelects.forEach(select => {
+        select.addEventListener('change', () => {
+            sendCurrentSettings();
+        });
+    });
+
     document.getElementById('reset-btn')?.addEventListener('click', () => {
         parent.postMessage({ pluginMessage: { type: 'reset-settings' } }, '*');
     });
@@ -485,6 +523,16 @@ function sendCurrentSettings() {
         }
     });
     settings.styleBindings = styleBindings;
+
+    // Include component bindings
+    const componentBindings: Record<string, string> = {};
+    componentBindingSelects.forEach(select => {
+        const key = select.dataset.binding;
+        if (key && select.value !== '') {
+            componentBindings[key] = select.value;
+        }
+    });
+    settings.componentBindings = componentBindings;
 
     // Determine active theme
     const activeThemeBtn = document.querySelector('.theme-btn.active') as HTMLButtonElement | null;
@@ -573,6 +621,9 @@ window.onmessage = event => {
             break;
         case 'local-styles':
             populateStyleDropdowns(msg.textStyles ?? []);
+            break;
+        case 'local-components':
+            populateComponentDropdowns(msg.components ?? []);
             break;
         case 'history':
             renderHistory(msg.entries ?? []);

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -1,6 +1,12 @@
 import './styles.css';
 import { marked } from 'marked';
 import { isValidHex, hasSupportedExtension } from '../utils';
+import {
+    MSG_GET_SETTINGS, MSG_SAVE_SETTINGS, MSG_RESET_SETTINGS,
+    MSG_GET_LOCAL_STYLES, MSG_GET_LOCAL_COMPONENTS,
+    MSG_GET_HISTORY, MSG_CLEAR_HISTORY, MSG_IMPORT_BATCH,
+    MSG_STATUS, MSG_SETTINGS, MSG_LOCAL_STYLES, MSG_LOCAL_COMPONENTS, MSG_HISTORY,
+} from '../messages';
 
 function escapeHtml(str: string): string {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -84,7 +90,6 @@ const THEME_PRESETS: Record<string, Record<string, unknown>> = {
 // ── State ───────────────────────────────────────────────────────────────────
 
 let currentFiles: { name: string; content: string }[] = [];
-let isPreviewVisible = false;
 
 // ── Tab switching ───────────────────────────────────────────────────────────
 
@@ -99,12 +104,12 @@ tabs.forEach(tab => {
         });
 
         if (tab.dataset.tab === 'settings') {
-            parent.postMessage({ pluginMessage: { type: 'get-settings' } }, '*');
-            parent.postMessage({ pluginMessage: { type: 'get-local-styles' } }, '*');
-            parent.postMessage({ pluginMessage: { type: 'get-local-components' } }, '*');
+            parent.postMessage({ pluginMessage: { type: MSG_GET_SETTINGS } }, '*');
+            parent.postMessage({ pluginMessage: { type: MSG_GET_LOCAL_STYLES } }, '*');
+            parent.postMessage({ pluginMessage: { type: MSG_GET_LOCAL_COMPONENTS } }, '*');
         }
         if (tab.dataset.tab === 'history') {
-            parent.postMessage({ pluginMessage: { type: 'get-history' } }, '*');
+            parent.postMessage({ pluginMessage: { type: MSG_GET_HISTORY } }, '*');
         }
     });
 });
@@ -251,7 +256,7 @@ function showPreview(files: { name: string; content: string }[]) {
     previewCancelBtn.classList.remove('hidden');
     importBtn.disabled = false;
     importBtn.textContent = files.length === 1 ? 'Import to Canvas' : `Import ${files.length} Files`;
-    isPreviewVisible = true;
+
 }
 
 function hidePreview() {
@@ -261,7 +266,7 @@ function hidePreview() {
     importSection.style.display = '';
     fileList.style.display = '';
     importBtn.textContent = 'Import';
-    isPreviewVisible = false;
+
 }
 
 // ── Paste ───────────────────────────────────────────────────────────────────
@@ -304,7 +309,7 @@ importBtn.addEventListener('click', () => {
 
     parent.postMessage({
         pluginMessage: {
-            type: 'import-markdown-batch',
+            type: MSG_IMPORT_BATCH,
             files: currentFiles,
             excludedBlocks,
         }
@@ -469,7 +474,7 @@ function setupSettingListeners() {
     });
 
     document.getElementById('reset-btn')?.addEventListener('click', () => {
-        parent.postMessage({ pluginMessage: { type: 'reset-settings' } }, '*');
+        parent.postMessage({ pluginMessage: { type: MSG_RESET_SETTINGS } }, '*');
     });
 }
 
@@ -516,7 +521,7 @@ function sendCurrentSettings() {
     const mode = settings.widthMode as string;
     settings.frameWidth = widthPresets[mode] ?? (settings.customWidth as number) ?? 800;
 
-    parent.postMessage({ pluginMessage: { type: 'save-settings', settings } }, '*');
+    parent.postMessage({ pluginMessage: { type: MSG_SAVE_SETTINGS, settings } }, '*');
 }
 
 setupSettingListeners();
@@ -556,7 +561,7 @@ function renderHistory(entries: Array<{ filename: string; timestamp: number; blo
 }
 
 clearHistoryBtn.addEventListener('click', () => {
-    parent.postMessage({ pluginMessage: { type: 'clear-history' } }, '*');
+    parent.postMessage({ pluginMessage: { type: MSG_CLEAR_HISTORY } }, '*');
 });
 
 // ── Status helper ───────────────────────────────────────────────────────────
@@ -573,9 +578,9 @@ window.onmessage = event => {
     if (!msg) return;
 
     switch (msg.type) {
-        case 'status':
+        case MSG_STATUS:
             loader.classList.add('hidden');
-            if (isPreviewVisible) hidePreview();
+            if (!previewPane.classList.contains('hidden')) hidePreview();
             importBtn.disabled = currentFiles.length === 0;
             showStatus(msg.message, msg.error ? 'error' : msg.warning ? 'warning' : 'success');
             // Clear paste area on successful import
@@ -587,16 +592,16 @@ window.onmessage = event => {
                 renderFileList([]);
             }
             break;
-        case 'settings':
+        case MSG_SETTINGS:
             populateSettings(msg.settings);
             break;
-        case 'local-styles':
+        case MSG_LOCAL_STYLES:
             populateDropdowns(styleBindingSelects, msg.textStyles ?? []);
             break;
-        case 'local-components':
+        case MSG_LOCAL_COMPONENTS:
             populateDropdowns(componentBindingSelects, msg.components ?? []);
             break;
-        case 'history':
+        case MSG_HISTORY:
             renderHistory(msg.entries ?? []);
             break;
         default:

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -256,7 +256,6 @@ function showPreview(files: { name: string; content: string }[]) {
     previewCancelBtn.classList.remove('hidden');
     importBtn.disabled = false;
     importBtn.textContent = files.length === 1 ? 'Import to Canvas' : `Import ${files.length} Files`;
-
 }
 
 function hidePreview() {
@@ -266,7 +265,6 @@ function hidePreview() {
     importSection.style.display = '';
     fileList.style.display = '';
     importBtn.textContent = 'Import';
-
 }
 
 // ── Paste ───────────────────────────────────────────────────────────────────

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -378,35 +378,19 @@ function populateSettings(settings: Record<string, unknown>) {
     updateCustomWidthVisibility();
 }
 
-function populateStyleDropdowns(textStyles: Array<{ id: string; name: string }>) {
-    styleBindingSelects.forEach(select => {
+/** Populates a set of <select> dropdowns with items, preserving current selections. */
+function populateDropdowns(
+    selects: NodeListOf<HTMLSelectElement>,
+    items: Array<{ id: string; name: string }>,
+) {
+    selects.forEach(select => {
         const currentValue = select.value;
-        // Clear all options except "Auto"
+        // Clear all options except the first default ("Auto" / "None")
         while (select.options.length > 1) select.remove(1);
-        // Add each local text style as an option
-        for (const style of textStyles) {
+        for (const item of items) {
             const opt = document.createElement('option');
-            opt.value = style.id;
-            opt.textContent = style.name;
-            select.appendChild(opt);
-        }
-        // Restore previous selection if it still exists
-        if (currentValue && Array.from(select.options).some(o => o.value === currentValue)) {
-            select.value = currentValue;
-        }
-    });
-}
-
-function populateComponentDropdowns(components: Array<{ id: string; name: string }>) {
-    componentBindingSelects.forEach(select => {
-        const currentValue = select.value;
-        // Clear all options except "None"
-        while (select.options.length > 1) select.remove(1);
-        // Add each local component as an option
-        for (const comp of components) {
-            const opt = document.createElement('option');
-            opt.value = comp.id;
-            opt.textContent = comp.name;
+            opt.value = item.id;
+            opt.textContent = item.name;
             select.appendChild(opt);
         }
         // Restore previous selection if it still exists
@@ -477,17 +461,10 @@ function setupSettingListeners() {
         });
     });
 
-    // Style binding selects
-    styleBindingSelects.forEach(select => {
-        select.addEventListener('change', () => {
-            sendCurrentSettings();
-        });
-    });
-
-    // Component binding selects
-    componentBindingSelects.forEach(select => {
-        select.addEventListener('change', () => {
-            sendCurrentSettings();
+    // Style and component binding selects
+    [styleBindingSelects, componentBindingSelects].forEach(selects => {
+        selects.forEach(select => {
+            select.addEventListener('change', () => sendCurrentSettings());
         });
     });
 
@@ -514,25 +491,19 @@ function sendCurrentSettings() {
         if (cb) settings[id] = cb.checked;
     }
 
-    // Include style bindings
-    const styleBindings: Record<string, string> = {};
-    styleBindingSelects.forEach(select => {
-        const key = select.dataset.binding;
-        if (key && select.value !== 'auto') {
-            styleBindings[key] = select.value;
-        }
-    });
-    settings.styleBindings = styleBindings;
-
-    // Include component bindings
-    const componentBindings: Record<string, string> = {};
-    componentBindingSelects.forEach(select => {
-        const key = select.dataset.binding;
-        if (key && select.value !== '') {
-            componentBindings[key] = select.value;
-        }
-    });
-    settings.componentBindings = componentBindings;
+    // Collect style and component bindings
+    function collectBindings(selects: NodeListOf<HTMLSelectElement>, defaultValue: string): Record<string, string> {
+        const bindings: Record<string, string> = {};
+        selects.forEach(select => {
+            const key = select.dataset.binding;
+            if (key && select.value !== defaultValue) {
+                bindings[key] = select.value;
+            }
+        });
+        return bindings;
+    }
+    settings.styleBindings = collectBindings(styleBindingSelects, 'auto');
+    settings.componentBindings = collectBindings(componentBindingSelects, '');
 
     // Determine active theme
     const activeThemeBtn = document.querySelector('.theme-btn.active') as HTMLButtonElement | null;
@@ -620,10 +591,10 @@ window.onmessage = event => {
             populateSettings(msg.settings);
             break;
         case 'local-styles':
-            populateStyleDropdowns(msg.textStyles ?? []);
+            populateDropdowns(styleBindingSelects, msg.textStyles ?? []);
             break;
         case 'local-components':
-            populateComponentDropdowns(msg.components ?? []);
+            populateDropdowns(componentBindingSelects, msg.components ?? []);
             break;
         case 'history':
             renderHistory(msg.entries ?? []);

--- a/figma-markdown-sync/test-setup.ts
+++ b/figma-markdown-sync/test-setup.ts
@@ -109,6 +109,7 @@ function makeMockRectangle(): any {
     currentPage: {
         appendChild: jest.fn(),
         findAll: jest.fn(() => []),
+        findAllWithCriteria: jest.fn(() => []),
         children: [],
     },
     editorType: 'figma',

--- a/figma-markdown-sync/test-setup.ts
+++ b/figma-markdown-sync/test-setup.ts
@@ -101,6 +101,7 @@ function makeMockRectangle(): any {
 }
 
 (global as any).figma = {
+    mixed: Symbol('figma.mixed'),
     showUI: jest.fn(),
     ui: {
         onmessage: null,

--- a/figma-markdown-sync/test-setup.ts
+++ b/figma-markdown-sync/test-setup.ts
@@ -125,6 +125,7 @@ function makeMockRectangle(): any {
     })),
     getLocalTextStylesAsync: jest.fn().mockResolvedValue([]),
     getStyleByIdAsync: jest.fn().mockResolvedValue(null),
+    getNodeByIdAsync: jest.fn().mockResolvedValue(null),
     createImageAsync: jest.fn().mockResolvedValue({
         hash: 'mock-hash',
         getSizeAsync: jest.fn().mockResolvedValue({ width: 800, height: 600 }),

--- a/figma-markdown-sync/ui.html
+++ b/figma-markdown-sync/ui.html
@@ -134,6 +134,16 @@
             <label class="settings-row"><span class="settings-label">Quote</span><div class="settings-input-wrap"><select class="style-binding-select settings-select" data-binding="quote"><option value="auto">Auto</option></select></div></label>
         </div>
 
+        <div class="settings-section" id="component-mapping-section">
+            <h3 class="settings-section-title">Component Mapping</h3>
+            <p class="settings-hint">Map block types to components on this page. Components need a <code>#content</code> text layer.</p>
+            <label class="settings-row"><span class="settings-label">Code Block</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="codeBlock"><option value="">None</option></select></div></label>
+            <label class="settings-row"><span class="settings-label">Blockquote</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="blockquote"><option value="">None</option></select></div></label>
+            <label class="settings-row"><span class="settings-label">Callout</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="callout"><option value="">None</option></select></div></label>
+            <label class="settings-row"><span class="settings-label">Table</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="table"><option value="">None</option></select></div></label>
+            <label class="settings-row"><span class="settings-label">Image</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="image"><option value="">None</option></select></div></label>
+        </div>
+
         <div class="settings-section">
             <h3 class="settings-section-title">Content</h3>
             <label class="settings-row">

--- a/figma-markdown-sync/ui.html
+++ b/figma-markdown-sync/ui.html
@@ -136,7 +136,7 @@
 
         <div class="settings-section" id="component-mapping-section">
             <h3 class="settings-section-title">Component Mapping</h3>
-            <p class="settings-hint">Map block types to components on this page. Components need a <code>#content</code> (or <code>#body</code>) text layer.</p>
+            <p class="settings-hint">Map block types to components on this page. Components need a <code>#content</code> (or <code>#body</code>) text layer. An optional <code>#title</code> (or <code>#label</code>) layer receives context like language or callout type.</p>
             <label class="settings-row"><span class="settings-label">Code Block</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="codeBlock"><option value="">None</option></select></div></label>
             <label class="settings-row"><span class="settings-label">Blockquote</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="blockquote"><option value="">None</option></select></div></label>
             <label class="settings-row"><span class="settings-label">Callout</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="callout"><option value="">None</option></select></div></label>

--- a/figma-markdown-sync/ui.html
+++ b/figma-markdown-sync/ui.html
@@ -136,7 +136,7 @@
 
         <div class="settings-section" id="component-mapping-section">
             <h3 class="settings-section-title">Component Mapping</h3>
-            <p class="settings-hint">Map block types to components on this page. Components need a <code>#content</code> text layer.</p>
+            <p class="settings-hint">Map block types to components on this page. Components need a <code>#content</code> (or <code>#body</code>) text layer.</p>
             <label class="settings-row"><span class="settings-label">Code Block</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="codeBlock"><option value="">None</option></select></div></label>
             <label class="settings-row"><span class="settings-label">Blockquote</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="blockquote"><option value="">None</option></select></div></label>
             <label class="settings-row"><span class="settings-label">Callout</span><div class="settings-input-wrap"><select class="component-binding-select settings-select" data-binding="callout"><option value="">None</option></select></div></label>


### PR DESCRIPTION
Add Component Output Mode (Feature #15) — users can map block types
(code, blockquote, callout, table, image) to their own Figma components.
The renderer instantiates the component and populates #content/#title
text layers automatically, falling back to default rendering when no
matching layer is found.

Changes:
- settings: add ComponentBindings type and validation
- blockRenderers: add tryRenderWithComponent with recursive layer search
- renderer: integrate component bindings for 5 block types
- code.ts: add get-local-components message handler
- UI: add Component Mapping section in settings with dropdowns
- tests: 12 new tests for settings validation and component rendering
- README: comprehensive update documenting all implemented v2 features

https://claude.ai/code/session_018Rt4Bu6paE1rbBFbP7eJmc