### PR TITLE
feat: Figma → Markdown export

### DIFF
--- a/docs/superpowers/plans/2026-03-12-export-figma-to-markdown.md
+++ b/docs/superpowers/plans/2026-03-12-export-figma-to-markdown.md
@@ -1,0 +1,1588 @@
+# Export: Figma → Markdown Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Figma → Markdown export pipeline: walk selected frame layer trees, diff inferred blocks against stored source, and download `.md` files with round-trip fidelity for plugin-created frames.
+
+**Architecture:** New `exporter.ts` handles all inference + diff + assembly logic. Four new message types wire the sandbox to the UI. `code.ts` stores `pluginData` on frames at import time and responds to export requests. The UI gets a new Export tab with auto-merge default and optional selective review mode. All innerHTML usage in the UI uses the existing `escapeHtml()` utility on user-derived content; plan reviewers should verify this pattern is followed in every instance.
+
+**Tech Stack:** TypeScript, Figma Plugin API, Jest 30.x
+
+**Spec:** `docs/superpowers/specs/2026-03-12-export-figma-to-markdown-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `figma-markdown-sync/exporter.ts` | **Create** | Layer-tree walker, inference rules for all 18 block types, content-hash diff engine, Markdown assembly |
+| `figma-markdown-sync/exporter.test.ts` | **Create** | Tests for inference, diff engine, assembly |
+| `figma-markdown-sync/messages.ts` | **Modify** | Add 4 new export message type constants + MSG_GET_SELECTION + MSG_SELECTION_CHANGED |
+| `figma-markdown-sync/code.ts` | **Modify** | Store `pluginData` after `renderBlocks`; handle export message types; listen for selectionchange |
+| `figma-markdown-sync/blockRenderers.ts` | **Modify** | Store `mermaidSource` / `mathSource` as `pluginData` on Mermaid and Math frames at render time |
+| `figma-markdown-sync/test-setup.ts` | **Modify** | Add `setPluginData` / `getPluginData` mocks to `makeMockFrame` |
+| `figma-markdown-sync/ui.html` | **Modify** | Add Export tab button and `#export-panel` tab panel |
+| `figma-markdown-sync/src/ui.ts` | **Modify** | Export tab logic: request diff on selection, render summary, review mode, trigger downloads |
+| `figma-markdown-sync/src/styles.css` | **Modify** | Styles for export panel, diff view, fidelity warning badges |
+
+**No changes to:** `parser.ts`, `renderer.ts`, `styles.ts`, `settings.ts`, `tables.ts`, `parser.test.ts`, `renderer.test.ts`, `styles.test.ts`, `settings.test.ts`, `tables.test.ts`
+
+---
+
+## Chunk 1: pluginData Storage at Import Time
+
+### Task 1: Add pluginData mocks to test-setup
+
+**Files:**
+- Modify: `figma-markdown-sync/test-setup.ts:7-51` (`makeMockFrame`)
+
+- [ ] **Step 1: Add `setPluginData` and `getPluginData` mocks to `makeMockFrame`**
+
+In `makeMockFrame()`, inside the frame object literal, add after the `remove` mock:
+
+```typescript
+_pluginData: {} as Record<string, string>,
+setPluginData: jest.fn(function(key: string, value: string) { frame._pluginData[key] = value; }),
+getPluginData: jest.fn(function(key: string) { return frame._pluginData[key] ?? ''; }),
+```
+
+- [ ] **Step 2: Run all tests to confirm no regressions**
+
+```bash
+cd figma-markdown-sync && npx jest --verbose
+```
+Expected: all existing tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add figma-markdown-sync/test-setup.ts
+git commit -m "test: add setPluginData/getPluginData mocks to makeMockFrame"
+```
+
+---
+
+### Task 2: Add export message type constants
+
+**Files:**
+- Modify: `figma-markdown-sync/messages.ts`
+
+- [ ] **Step 1: Add the 6 export/selection message constants**
+
+Append to `messages.ts`:
+
+```typescript
+// ── Export (UI → Sandbox) ────────────────────────────────────────────────────
+
+export const MSG_EXPORT_REQUEST  = 'export-request';   // UI sends selected frame IDs
+export const MSG_EXPORT_DOWNLOAD = 'export-download';  // UI sends frame ID + block selections
+export const MSG_GET_SELECTION   = 'get-selection';    // UI asks sandbox for current selection
+
+// ── Export (Sandbox → UI) ────────────────────────────────────────────────────
+
+export const MSG_EXPORT_RESULT      = 'export-result';      // Sandbox returns diff result per frame
+export const MSG_EXPORT_MARKDOWN    = 'export-markdown';    // Sandbox returns assembled Markdown string
+export const MSG_SELECTION_CHANGED  = 'selection-changed';  // Sandbox notifies UI of frame selection change
+```
+
+- [ ] **Step 2: Run tests to confirm no regressions**
+
+```bash
+npx jest --verbose
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add figma-markdown-sync/messages.ts
+git commit -m "feat: add export and selection message type constants"
+```
+
+---
+
+### Task 3: Store mermaidSource / mathSource pluginData in blockRenderers
+
+**Files:**
+- Modify: `figma-markdown-sync/blockRenderers.ts` (`renderMermaidBlock` ~line 418, `renderMathBlock` ~line 450)
+
+- [ ] **Step 1: In `renderMermaidBlock`, store source after building the frame**
+
+After `mermaidFrame.appendChild(sourceNode)`, add:
+
+```typescript
+mermaidFrame.setPluginData('mermaidSource', block.content ?? '');
+```
+
+- [ ] **Step 2: In `renderMathBlock`, store source after the math text is appended**
+
+After the math text node is appended to `mathFrame`, add:
+
+```typescript
+mathFrame.setPluginData('mathSource', block.content ?? '');
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npx jest --verbose
+```
+Expected: all pass. `setPluginData` is now mocked so no new test changes needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add figma-markdown-sync/blockRenderers.ts
+git commit -m "feat: store mermaid/math source as pluginData for round-trip export"
+```
+
+---
+
+### Task 4: Store markdownSource pluginData in code.ts
+
+**Files:**
+- Modify: `figma-markdown-sync/code.ts:163-167` (inside `MSG_IMPORT_BATCH` loop, after `renderBlocks`)
+
+- [ ] **Step 1: After `renderBlocks` resolves, store the pluginData keys**
+
+Find this code (around line 163):
+
+```typescript
+const result: RenderResult = await renderBlocks(nameNoExt, blocks, settings, target as SceneNode);
+updatedCount++;
+totalImageFailures += result.imageFailures;
+```
+
+Add immediately after:
+
+```typescript
+// Store source for round-trip export. Skip if > 50 KB to avoid pluginData limits.
+if (file.content.length <= 50_000) {
+    result.frame.setPluginData('markdownSource', file.content);
+    result.frame.setPluginData('markdownFilename', file.name);
+    result.frame.setPluginData('markdownImportedAt', Date.now().toString());
+} else {
+    result.frame.setPluginData('markdownSourceTruncated', 'true');
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npx jest --verbose
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add figma-markdown-sync/code.ts
+git commit -m "feat: store markdownSource pluginData on import for round-trip export"
+```
+
+---
+
+## Chunk 2: Layer-Tree Inference Engine
+
+### Task 5: Create exporter.ts with types, helpers, and text-node inference
+
+**Files:**
+- Create: `figma-markdown-sync/exporter.ts`
+- Create: `figma-markdown-sync/exporter.test.ts`
+
+- [ ] **Step 1: Write failing tests for type definitions and basic helpers**
+
+Create `figma-markdown-sync/exporter.test.ts`:
+
+```typescript
+/**
+ * Tests for exporter.ts — inference, diff engine, and Markdown assembly.
+ */
+import {
+    inferBlocksFromFrame,
+    normalizeContent,
+    fingerprintBlock,
+    diffBlocks,
+    assembleMarkdown,
+} from './exporter';
+import type { InferredBlock, DiffBlock, BlockSelection } from './exporter';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTextNode(overrides: Partial<any> = {}): any {
+    return {
+        type: 'TEXT',
+        name: '',
+        characters: 'Hello world',
+        _pluginData: {} as Record<string, string>,
+        getPluginData: jest.fn(function(this: any, k: string) { return this._pluginData[k] ?? ''; }),
+        getTextStyleIdAsync: jest.fn().mockResolvedValue(''),
+        ...overrides,
+    };
+}
+
+function makeRectNode(overrides: Partial<any> = {}): any {
+    return {
+        type: 'RECTANGLE',
+        name: '',
+        width: 800,
+        height: 1,
+        fills: [{ type: 'SOLID' }],
+        ...overrides,
+    };
+}
+
+function makeFrame(name: string, children: any[] = [], overrides: Partial<any> = {}): any {
+    return {
+        type: 'FRAME',
+        name,
+        children,
+        _pluginData: {} as Record<string, string>,
+        getPluginData: jest.fn(function(this: any, k: string) { return this._pluginData[k] ?? ''; }),
+        ...overrides,
+    };
+}
+
+// ── normalizeContent ─────────────────────────────────────────────────────────
+
+describe('normalizeContent', () => {
+    it('strips leading and trailing whitespace', () => {
+        expect(normalizeContent('  hello  ')).toBe('hello');
+    });
+
+    it('collapses internal whitespace runs to a single space', () => {
+        expect(normalizeContent('foo   bar\tbaz')).toBe('foo bar baz');
+    });
+
+    it('returns empty string for blank input', () => {
+        expect(normalizeContent('   ')).toBe('');
+    });
+});
+
+// ── fingerprintBlock ─────────────────────────────────────────────────────────
+
+describe('fingerprintBlock', () => {
+    it('produces type:normalizedContent string', () => {
+        expect(fingerprintBlock('heading', '  Hello World  ')).toBe('heading:Hello World');
+    });
+
+    it('is case-sensitive', () => {
+        expect(fingerprintBlock('paragraph', 'Foo')).not.toBe(fingerprintBlock('paragraph', 'foo'));
+    });
+});
+
+// ── inferBlocksFromFrame — text and separator nodes ───────────────────────────
+
+describe('inferBlocksFromFrame — text nodes', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('infers H1 from a text node with Markdown/H1 style name', async () => {
+        const text = makeTextNode({ characters: 'My Title' });
+        (figma.getStyleByIdAsync as jest.Mock).mockResolvedValue({ name: 'Markdown/H1' });
+        text.getTextStyleIdAsync.mockResolvedValue('style-id-h1');
+        const frame = makeFrame('Test', [text]);
+
+        const { blocks } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].text).toBe('# My Title');
+        expect(blocks[0].blockType).toBe('heading-1');
+    });
+
+    it('infers paragraph from Markdown/Body style', async () => {
+        const text = makeTextNode({ characters: 'Some body text' });
+        (figma.getStyleByIdAsync as jest.Mock).mockResolvedValue({ name: 'Markdown/Body' });
+        text.getTextStyleIdAsync.mockResolvedValue('style-id-body');
+        const frame = makeFrame('Test', [text]);
+
+        const { blocks } = await inferBlocksFromFrame(frame);
+        expect(blocks[0].text).toBe('Some body text');
+        expect(blocks[0].blockType).toBe('paragraph');
+    });
+
+    it('infers separator from a 1px-tall RECTANGLE node', async () => {
+        const rect = makeRectNode({ height: 1 });
+        const frame = makeFrame('Test', [rect]);
+
+        const { blocks } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].text).toBe('---');
+        expect(blocks[0].blockType).toBe('separator');
+    });
+
+    it('skips unknown nodes and records them in skippedLayers', async () => {
+        const unknown = { type: 'ELLIPSE', name: 'Shape', children: [] };
+        const frame = makeFrame('Test', [unknown]);
+
+        const { blocks, skippedLayers } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(0);
+        expect(skippedLayers[0].name).toBe('Shape');
+    });
+});
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+npx jest exporter --verbose
+```
+Expected: FAIL — `exporter.ts` not found.
+
+- [ ] **Step 3: Create `exporter.ts` with types and helpers**
+
+Create `figma-markdown-sync/exporter.ts`:
+
+```typescript
+/**
+ * exporter.ts
+ *
+ * Figma → Markdown export pipeline.
+ *
+ * Stages:
+ *   1. inferBlocksFromFrame  — walk layer tree, produce InferredBlock[]
+ *   2. diffBlocks            — compare inferred vs stored source blocks
+ *   3. assembleMarkdown      — merge diff result into final Markdown string
+ *
+ * This module only reads existing Figma nodes — no rendering occurs here.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface InferredBlock {
+    text: string;
+    blockType: string;
+    label: string;
+    fidelityWarning?: string;
+}
+
+export interface DiffBlock {
+    state: 'unchanged' | 'modified' | 'new';
+    originalText?: string;
+    inferredText: string;
+    label: string;
+    fidelityWarning?: string;
+}
+
+export interface ExportFrameResult {
+    frameId: string;
+    filename: string;
+    hasStoredSource: boolean;
+    sourceTruncated: boolean;
+    blocks: DiffBlock[];
+    skippedLayers: Array<{ name: string; reason: string }>;
+}
+
+export interface BlockSelection {
+    blockIndex: number;
+    useOriginal: boolean;
+}
+
+// ─── Helpers (exported for testing) ──────────────────────────────────────────
+
+/** Strips leading/trailing whitespace and collapses internal runs to one space. */
+export function normalizeContent(text: string): string {
+    return text.trim().replace(/\s+/g, ' ');
+}
+
+/** Produces a stable fingerprint: "type:normalizedContent" */
+export function fingerprintBlock(blockType: string, content: string): string {
+    return `${blockType}:${normalizeContent(content)}`;
+}
+
+// ─── Style name → block type mapping ─────────────────────────────────────────
+
+const STYLE_TO_BLOCK: Record<string, { blockType: string; label: string; prefix: string }> = {
+    'Markdown/H1':    { blockType: 'heading-1', label: 'Heading 1',  prefix: '# '  },
+    'Markdown/H2':    { blockType: 'heading-2', label: 'Heading 2',  prefix: '## ' },
+    'Markdown/H3':    { blockType: 'heading-3', label: 'Heading 3',  prefix: '### '},
+    'Markdown/Body':  { blockType: 'paragraph', label: 'Paragraph',  prefix: ''    },
+    'Markdown/Code':  { blockType: 'code',      label: 'Code Block', prefix: ''    },
+    'Markdown/Quote': { blockType: 'quote',     label: 'Blockquote', prefix: '> '  },
+    'Markdown/List':  { blockType: 'list',      label: 'List Item',  prefix: '- '  },
+};
+
+const FRAME_NAME_TO_BLOCK: Record<string, string> = {
+    'Table':             'table',
+    'List Group':        'listGroup',
+    'Table of Contents': 'toc',
+    'Definition List':   'definitionList',
+    'Footnotes':         'footnoteSection',
+    'Badge Row':         'badgeRow',
+    'Mermaid Diagram':   'mermaid',
+    'Math Block':        'math',
+};
+
+// ─── Inference ────────────────────────────────────────────────────────────────
+
+interface InferenceResult {
+    blocks: InferredBlock[];
+    skippedLayers: Array<{ name: string; reason: string }>;
+}
+
+export async function inferBlocksFromFrame(frame: any): Promise<InferenceResult> {
+    const blocks: InferredBlock[] = [];
+    const skippedLayers: Array<{ name: string; reason: string }> = [];
+
+    for (const child of (frame.children ?? [])) {
+        const inferred = await inferNode(child);
+        if (inferred) {
+            blocks.push(inferred);
+        } else {
+            skippedLayers.push({ name: child.name || '(unnamed)', reason: 'Unrecognized layer type or name' });
+        }
+    }
+
+    return { blocks, skippedLayers };
+}
+
+async function inferNode(node: any): Promise<InferredBlock | null> {
+    if (node.type === 'RECTANGLE' && node.height === 1) {
+        return { text: '---', blockType: 'separator', label: 'Separator' };
+    }
+
+    if (node.type === 'RECTANGLE' && node.height > 1 &&
+        Array.isArray(node.fills) && node.fills[0]?.type === 'IMAGE') {
+        return {
+            text: `![${node.name || 'image'}](image-not-recoverable)`,
+            blockType: 'image',
+            label: 'Image',
+            fidelityWarning: 'Image URL not recoverable — update the URL manually after export.',
+        };
+    }
+
+    if (node.type === 'TEXT') return inferTextNode(node);
+    if (node.type === 'FRAME') return inferFrameNode(node);
+
+    return null;
+}
+
+async function inferTextNode(node: any): Promise<InferredBlock | null> {
+    const styleId = await node.getTextStyleIdAsync();
+    const style = styleId ? await figma.getStyleByIdAsync(styleId) : null;
+    const styleName: string = style?.name ?? '';
+    const mapping = STYLE_TO_BLOCK[styleName];
+    if (!mapping) return null;
+
+    const text = node.characters as string;
+    if (mapping.blockType === 'code') {
+        return { text: `\`\`\`\n${text}\n\`\`\``, blockType: 'code', label: 'Code Block' };
+    }
+    return { text: mapping.prefix + text, blockType: mapping.blockType, label: mapping.label };
+}
+
+async function inferFrameNode(node: any): Promise<InferredBlock | null> {
+    const blockType = FRAME_NAME_TO_BLOCK[node.name];
+
+    if (!blockType) {
+        if (node.name?.startsWith('Callout: ')) return inferCalloutFrame(node);
+        return null;
+    }
+
+    switch (blockType) {
+        case 'table':           return inferTableFrame(node);
+        case 'listGroup':       return inferListGroupFrame(node);
+        case 'mermaid':         return inferMermaidFrame(node);
+        case 'math':            return inferMathFrame(node);
+        case 'definitionList':  return inferDefinitionListFrame(node);
+        case 'footnoteSection': return inferFootnotesFrame(node);
+        case 'badgeRow':        return inferBadgeRowFrame(node);
+        case 'toc':
+            return {
+                text: '',
+                blockType: 'toc',
+                label: 'Table of Contents',
+                fidelityWarning: 'TOC is auto-generated on re-import — skipped in export output.',
+            };
+        default: return null;
+    }
+}
+
+function inferMermaidFrame(node: any): InferredBlock {
+    const source: string = node.getPluginData('mermaidSource');
+    return {
+        text: `\`\`\`mermaid\n${source}\n\`\`\``,
+        blockType: 'mermaid',
+        label: 'Mermaid Diagram',
+        fidelityWarning: source.length === 0 ? 'Mermaid source not recoverable — original source used if available.' : undefined,
+    };
+}
+
+function inferMathFrame(node: any): InferredBlock {
+    const source: string = node.getPluginData('mathSource');
+    return {
+        text: `$$\n${source}\n$$`,
+        blockType: 'math',
+        label: 'Math Block',
+        fidelityWarning: source.length === 0 ? 'Math source not recoverable — original source used if available.' : undefined,
+    };
+}
+
+function inferCalloutFrame(node: any): InferredBlock {
+    const typeLabel = node.name.replace('Callout: ', '').toUpperCase();
+    const bodyLines: string[] = [];
+    for (const child of (node.children ?? [])) {
+        if (child.type === 'TEXT' && child.characters) {
+            bodyLines.push(`> ${child.characters}`);
+        }
+    }
+    return {
+        text: `> [!${typeLabel}]\n${bodyLines.join('\n')}`,
+        blockType: 'callout',
+        label: `Callout (${typeLabel})`,
+    };
+}
+
+async function inferListGroupFrame(node: any): Promise<InferredBlock> {
+    const lines: string[] = [];
+    for (const child of (node.children ?? [])) {
+        if (child.type === 'TEXT') {
+            lines.push(`- ${child.characters}`);
+        } else if (child.type === 'FRAME') {
+            for (const grandchild of (child.children ?? [])) {
+                if (grandchild.type === 'TEXT' && grandchild.characters) {
+                    const isChecked = child.name === 'Task (done)';
+                    lines.push(`- [${isChecked ? 'x' : ' '}] ${grandchild.characters}`);
+                    break;
+                }
+            }
+        }
+    }
+    return { text: lines.join('\n'), blockType: 'listGroup', label: 'List' };
+}
+
+function inferTableFrame(node: any): InferredBlock {
+    const rows: string[][] = [];
+    for (const child of (node.children ?? [])) {
+        const rowCells: string[] = [];
+        for (const cell of (child.children ?? [])) {
+            const textNode = (cell.children ?? []).find((n: any) => n.type === 'TEXT');
+            rowCells.push(textNode?.characters ?? '');
+        }
+        if (rowCells.length > 0) rows.push(rowCells);
+    }
+    if (rows.length === 0) return { text: '', blockType: 'table', label: 'Table' };
+    const toRow = (cells: string[]) => `| ${cells.join(' | ')} |`;
+    const sep = rows[0].map(() => '---');
+    return {
+        text: [toRow(rows[0]), toRow(sep), ...rows.slice(1).map(toRow)].join('\n'),
+        blockType: 'table',
+        label: 'Table',
+    };
+}
+
+function inferDefinitionListFrame(node: any): InferredBlock {
+    const lines: string[] = [];
+    const texts = (node.children ?? []).filter((n: any) => n.type === 'TEXT');
+    for (let i = 0; i < texts.length; i += 2) {
+        if (texts[i]) lines.push(texts[i].characters);
+        if (texts[i + 1]) lines.push(`: ${texts[i + 1].characters}`);
+    }
+    return { text: lines.join('\n'), blockType: 'definitionList', label: 'Definition List' };
+}
+
+function inferFootnotesFrame(node: any): InferredBlock {
+    const lines: string[] = [];
+    const texts = (node.children ?? []).filter((n: any) => n.type === 'TEXT');
+    texts.forEach((t: any, i: number) => { lines.push(`[^${i + 1}]: ${t.characters}`); });
+    return { text: lines.join('\n'), blockType: 'footnoteSection', label: 'Footnotes' };
+}
+
+function inferBadgeRowFrame(node: any): InferredBlock {
+    const badges = (node.children ?? [])
+        .filter((c: any) => c.name?.startsWith('Badge: '))
+        .map((c: any) => `[badge:${c.name.replace('Badge: ', '')}]`);
+    return { text: badges.join(' '), blockType: 'badgeRow', label: 'Badge Row' };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npx jest exporter --verbose
+```
+Expected: normalizeContent, fingerprintBlock, and inference tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add figma-markdown-sync/exporter.ts figma-markdown-sync/exporter.test.ts
+git commit -m "feat: create exporter.ts with inference engine for all 18 block types"
+```
+
+---
+
+## Chunk 3: Diff Engine and Markdown Assembly
+
+### Task 6: Implement diffBlocks
+
+**Files:**
+- Modify: `figma-markdown-sync/exporter.ts`
+- Modify: `figma-markdown-sync/exporter.test.ts`
+
+- [ ] **Step 1: Write failing tests for diffBlocks**
+
+Add to `exporter.test.ts`:
+
+```typescript
+// ── diffBlocks ────────────────────────────────────────────────────────────────
+
+describe('diffBlocks', () => {
+    const makeInferred = (blockType: string, text: string, label = blockType): InferredBlock =>
+        ({ text, blockType, label });
+
+    it('marks blocks as unchanged when fingerprints match', () => {
+        const result = diffBlocks(['# Hello World'], [makeInferred('heading-1', '# Hello World', 'Heading 1')]);
+        expect(result[0].state).toBe('unchanged');
+        expect(result[0].originalText).toBe('# Hello World');
+    });
+
+    it('marks blocks as modified when same position, different content', () => {
+        const result = diffBlocks(['# Old Title'], [makeInferred('heading-1', '# New Title', 'Heading 1')]);
+        expect(result[0].state).toBe('modified');
+        expect(result[0].originalText).toBe('# Old Title');
+        expect(result[0].inferredText).toBe('# New Title');
+    });
+
+    it('marks blocks as new when no source block exists', () => {
+        const result = diffBlocks([], [makeInferred('paragraph', 'New paragraph', 'Paragraph')]);
+        expect(result[0].state).toBe('new');
+        expect(result[0].originalText).toBeUndefined();
+    });
+
+    it('uses content-hash matching across positions (insertion tolerance)', () => {
+        const source = ['First paragraph', 'Second paragraph'];
+        const inferred = [
+            makeInferred('paragraph', 'Brand new intro', 'Paragraph'),
+            makeInferred('paragraph', 'First paragraph', 'Paragraph'),
+            makeInferred('paragraph', 'Second paragraph', 'Paragraph'),
+        ];
+        const result = diffBlocks(source, inferred);
+        expect(result.find(b => b.inferredText === 'Brand new intro')?.state).toBe('new');
+        expect(result.find(b => b.inferredText === 'First paragraph')?.state).toBe('unchanged');
+        expect(result.find(b => b.inferredText === 'Second paragraph')?.state).toBe('unchanged');
+    });
+
+    it('returns empty array when both inputs are empty', () => {
+        expect(diffBlocks([], [])).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+npx jest exporter --verbose
+```
+
+- [ ] **Step 3: Implement `diffBlocks` and `guessBlockType` in exporter.ts**
+
+Add after the inference functions:
+
+```typescript
+// ─── Diff engine ─────────────────────────────────────────────────────────────
+
+/**
+ * Heuristic: infer block type from Markdown text prefix, for fingerprinting
+ * source lines that were not produced by the inference engine.
+ */
+function guessBlockType(text: string): string {
+    if (text.startsWith('# '))   return 'heading-1';
+    if (text.startsWith('## '))  return 'heading-2';
+    if (text.startsWith('### ')) return 'heading-3';
+    if (text.startsWith('> [!')) return 'callout';
+    if (text.startsWith('> '))   return 'quote';
+    if (text.startsWith('- ') || text.startsWith('* ')) return 'list';
+    if (text.startsWith('---'))  return 'separator';
+    if (text.startsWith('```'))  return 'code';
+    if (text.startsWith('$$'))   return 'math';
+    if (text.startsWith('|'))    return 'table';
+    return 'paragraph';
+}
+
+/**
+ * Diffs source Markdown strings against inferred blocks using content-hash
+ * matching with position+type as fallback.
+ *
+ * @param sourceLines - Markdown strings from stored pluginData, split by double-newline.
+ * @param inferredBlocks - Output of inferBlocksFromFrame.
+ */
+export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[]): DiffBlock[] {
+    // Build source fingerprint map for O(1) content-hash lookup
+    const sourceByFingerprint = new Map<string, string>();
+    for (const line of sourceLines) {
+        const fp = fingerprintBlock(guessBlockType(line), line);
+        sourceByFingerprint.set(fp, line);
+    }
+
+    const usedSourceIndices = new Set<number>();
+    const result: DiffBlock[] = [];
+
+    for (let i = 0; i < inferredBlocks.length; i++) {
+        const inferred = inferredBlocks[i];
+        const fp = fingerprintBlock(inferred.blockType, inferred.text);
+
+        // 1. Content-hash match — position-independent
+        if (sourceByFingerprint.has(fp)) {
+            const originalText = sourceByFingerprint.get(fp)!;
+            sourceByFingerprint.delete(fp); // consume to prevent duplicate matches
+            result.push({ state: 'unchanged', originalText, inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+            continue;
+        }
+
+        // 2. Position+type fallback
+        const sourceLine = sourceLines[i];
+        if (sourceLine !== undefined && guessBlockType(sourceLine) === inferred.blockType && !usedSourceIndices.has(i)) {
+            usedSourceIndices.add(i);
+            result.push({ state: 'modified', originalText: sourceLine, inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+            continue;
+        }
+
+        // 3. New block
+        result.push({ state: 'new', inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+    }
+
+    return result;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npx jest exporter --verbose
+```
+Expected: all diffBlocks tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add figma-markdown-sync/exporter.ts figma-markdown-sync/exporter.test.ts
+git commit -m "feat: implement content-hash diff engine in exporter"
+```
+
+---
+
+### Task 7: Implement assembleMarkdown and exportFrame
+
+**Files:**
+- Modify: `figma-markdown-sync/exporter.ts`
+- Modify: `figma-markdown-sync/exporter.test.ts`
+
+- [ ] **Step 1: Write failing tests for assembleMarkdown**
+
+Add to `exporter.test.ts`:
+
+```typescript
+// ── assembleMarkdown ──────────────────────────────────────────────────────────
+
+describe('assembleMarkdown', () => {
+    it('uses originalText for unchanged blocks (preserves inline formatting)', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'unchanged', originalText: '# My [linked](url) Heading', inferredText: '# My linked Heading', label: 'Heading 1' },
+        ];
+        expect(assembleMarkdown(blocks, [])).toBe('# My [linked](url) Heading');
+    });
+
+    it('uses inferredText for new blocks', () => {
+        const blocks: DiffBlock[] = [{ state: 'new', inferredText: 'New paragraph', label: 'Paragraph' }];
+        expect(assembleMarkdown(blocks, [])).toBe('New paragraph');
+    });
+
+    it('uses originalText by default for modified blocks (conservative)', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'modified', originalText: 'Old text', inferredText: 'New text', label: 'Paragraph' },
+        ];
+        expect(assembleMarkdown(blocks, [])).toBe('Old text');
+    });
+
+    it('respects BlockSelection to use inferred for modified block', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'modified', originalText: 'Old text', inferredText: 'New text', label: 'Paragraph' },
+        ];
+        expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: false }])).toBe('New text');
+    });
+
+    it('respects BlockSelection useOriginal=true to skip a new block', () => {
+        const blocks: DiffBlock[] = [{ state: 'new', inferredText: 'Unwanted', label: 'Paragraph' }];
+        expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: true }])).toBe('');
+    });
+
+    it('separates blocks with a blank line', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'unchanged', originalText: '# Title', inferredText: '# Title', label: 'Heading 1' },
+            { state: 'new', inferredText: 'Body text', label: 'Paragraph' },
+        ];
+        expect(assembleMarkdown(blocks, [])).toBe('# Title\n\nBody text');
+    });
+});
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+npx jest exporter --verbose
+```
+
+- [ ] **Step 3: Implement `assembleMarkdown` and `exportFrame`**
+
+Add to `exporter.ts`:
+
+```typescript
+// ─── Assembly ─────────────────────────────────────────────────────────────────
+
+/**
+ * Merges DiffBlocks into a final Markdown string.
+ *
+ * Defaults per state:
+ *   unchanged → originalText (preserves inline links, footnotes, etc.)
+ *   modified  → originalText (conservative; user can override in review mode)
+ *   new       → inferredText (include by default)
+ *
+ * For 'new' blocks: useOriginal = true means "skip this block".
+ * Blocks are joined with a single blank line between them.
+ */
+export function assembleMarkdown(blocks: DiffBlock[], selections: BlockSelection[]): string {
+    const selMap = new Map(selections.map(s => [s.blockIndex, s.useOriginal]));
+    const lines: string[] = [];
+
+    for (let i = 0; i < blocks.length; i++) {
+        const block = blocks[i];
+        const override = selMap.get(i);
+        let text: string;
+
+        if (block.state === 'unchanged') {
+            text = block.originalText!;
+        } else if (block.state === 'modified') {
+            const useOriginal = override !== undefined ? override : true;
+            text = useOriginal ? block.originalText! : block.inferredText;
+        } else {
+            if (override === true) continue; // skip
+            text = block.inferredText;
+        }
+
+        if (text.trim().length > 0) lines.push(text);
+    }
+
+    return lines.join('\n\n');
+}
+
+// ─── Top-level export function ────────────────────────────────────────────────
+
+/**
+ * Runs the full 4-stage export pipeline for a single Figma FrameNode.
+ * Returns an ExportFrameResult ready to send to the UI via postMessage.
+ */
+export async function exportFrame(frame: any): Promise<ExportFrameResult> {
+    const frameId: string = frame.id;
+    const storedSource: string = frame.getPluginData('markdownSource');
+    const storedFilename: string = frame.getPluginData('markdownFilename');
+    const sourceTruncated: boolean = frame.getPluginData('markdownSourceTruncated') === 'true';
+    const hasStoredSource: boolean = storedSource.length > 0 && !sourceTruncated;
+
+    const rawFilename = storedFilename || frame.name || 'export';
+    const filename = rawFilename.replace(/\.md$/i, '') + '.md';
+
+    const { blocks: inferredBlocks, skippedLayers } = await inferBlocksFromFrame(frame);
+
+    let diffResult: DiffBlock[];
+
+    if (hasStoredSource) {
+        const sourceLines = storedSource
+            .split(/\n\n+/)
+            .map((s: string) => s.trim())
+            .filter((s: string) => s.length > 0);
+        diffResult = diffBlocks(sourceLines, inferredBlocks);
+    } else {
+        diffResult = inferredBlocks.map(b => ({
+            state: 'new' as const,
+            inferredText: b.text,
+            label: b.label,
+            fidelityWarning: b.fidelityWarning,
+        }));
+    }
+
+    return { frameId, filename, hasStoredSource, sourceTruncated, blocks: diffResult, skippedLayers };
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+npx jest --verbose
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Build**
+
+```bash
+npm run build
+```
+Expected: no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add figma-markdown-sync/exporter.ts figma-markdown-sync/exporter.test.ts
+git commit -m "feat: implement assembleMarkdown and exportFrame pipeline"
+```
+
+---
+
+### Task 8: Wire export handlers in code.ts
+
+**Files:**
+- Modify: `figma-markdown-sync/code.ts`
+
+- [ ] **Step 1: Add imports to code.ts**
+
+Add to the import block at the top of `code.ts`:
+
+```typescript
+import { exportFrame, assembleMarkdown } from './exporter';
+import {
+    MSG_EXPORT_REQUEST, MSG_EXPORT_DOWNLOAD, MSG_GET_SELECTION,
+    MSG_EXPORT_RESULT, MSG_EXPORT_MARKDOWN, MSG_SELECTION_CHANGED,
+} from './messages';
+```
+
+- [ ] **Step 2: Add export message handlers**
+
+Inside the `figma.ui.onmessage` block, after the `MSG_CLEAR_HISTORY` handler, add:
+
+```typescript
+if (msg.type === MSG_GET_SELECTION) {
+    const selectedFrameIds = figma.currentPage.selection
+        .filter(n => n.type === 'FRAME')
+        .map(n => n.id);
+    figma.ui.postMessage({ type: MSG_SELECTION_CHANGED, frameIds: selectedFrameIds });
+    return;
+}
+
+if (msg.type === MSG_EXPORT_REQUEST) {
+    const frameIds: string[] = msg.frameIds ?? [];
+    const results = [];
+    for (const id of frameIds) {
+        const node = await figma.getNodeByIdAsync(id);
+        if (!node || node.type !== 'FRAME') continue;
+        try {
+            results.push(await exportFrame(node));
+        } catch (err) {
+            console.error(`[MarkDown For What] Export failed for frame ${id}:`, err);
+        }
+    }
+    figma.ui.postMessage({ type: MSG_EXPORT_RESULT, frames: results });
+    return;
+}
+
+if (msg.type === MSG_EXPORT_DOWNLOAD) {
+    const node = await figma.getNodeByIdAsync(msg.frameId);
+    if (!node || node.type !== 'FRAME') {
+        figma.ui.postMessage({ type: MSG_STATUS, message: 'Frame not found.', error: true });
+        return;
+    }
+    const result = await exportFrame(node);
+    const content = assembleMarkdown(result.blocks, msg.selections ?? []);
+    figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: result.filename, content });
+    return;
+}
+```
+
+- [ ] **Step 3: Add selectionchange listener**
+
+Inside the plugin initialization IIFE in `code.ts`, after `figma.ui.onmessage = ...`:
+
+```typescript
+figma.on('selectionchange', () => {
+    const selectedFrameIds = figma.currentPage.selection
+        .filter(n => n.type === 'FRAME')
+        .map(n => n.id);
+    figma.ui.postMessage({ type: MSG_SELECTION_CHANGED, frameIds: selectedFrameIds });
+});
+```
+
+- [ ] **Step 4: Run tests and build**
+
+```bash
+npx jest --verbose && npm run build
+```
+Expected: all tests pass, no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add figma-markdown-sync/code.ts
+git commit -m "feat: wire export and selection handlers in code.ts"
+```
+
+---
+
+## Chunk 4: Export Tab UI
+
+### Task 9: Add Export tab to ui.html
+
+**Files:**
+- Modify: `figma-markdown-sync/ui.html`
+
+- [ ] **Step 1: Add Export tab button**
+
+Find the tab button row (elements with `class="tab"` and `data-tab` attributes). Add:
+
+```html
+<button class="tab" data-tab="export">Export</button>
+```
+
+- [ ] **Step 2: Add Export tab panel**
+
+After the last existing tab panel `</section>`, add:
+
+```html
+<section id="export-panel" class="tab-panel" hidden>
+  <div id="export-no-selection" class="export-empty">
+    <p>Select one or more frames on the canvas to export them as Markdown.</p>
+  </div>
+
+  <div id="export-frame-summary" hidden>
+    <div id="export-frame-info"></div>
+    <div id="export-block-counts"></div>
+    <div id="export-truncated-warning" class="export-warning" hidden>
+      Source too large to store — using current state only.
+    </div>
+    <div id="export-actions">
+      <button id="export-btn" class="btn-primary" disabled>Export .md</button>
+      <button id="export-review-btn" class="btn-secondary" hidden>Review changes</button>
+    </div>
+  </div>
+
+  <div id="export-review-panel" hidden>
+    <div id="export-review-breadcrumb" hidden></div>
+    <div id="export-review-blocks"></div>
+    <button id="export-review-back" class="btn-link">Back to export</button>
+    <button id="export-confirm-btn" class="btn-primary">Export .md</button>
+  </div>
+
+  <div id="export-log-panel" hidden>
+    <details>
+      <summary>Export log</summary>
+      <pre id="export-log-content"></pre>
+    </details>
+  </div>
+</section>
+```
+
+- [ ] **Step 3: Build and verify tab appears**
+
+```bash
+npm run build
+```
+Load plugin in Figma. Confirm Export tab shows and clicking it reveals the empty state.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add figma-markdown-sync/ui.html
+git commit -m "feat: add Export tab panel to plugin UI"
+```
+
+---
+
+### Task 10: Implement Export tab logic in ui.ts
+
+**Files:**
+- Modify: `figma-markdown-sync/src/ui.ts`
+- Modify: `figma-markdown-sync/src/styles.css`
+
+**Security note:** All user-derived content (frame names, block text, layer names) must be passed through the existing `escapeHtml()` function before being set as innerHTML. Plain structural HTML (buttons, divs, labels) does not require escaping.
+
+- [ ] **Step 1: Add imports for new message types in ui.ts**
+
+Add to the import statement in `ui.ts`:
+
+```typescript
+import {
+    MSG_EXPORT_REQUEST, MSG_EXPORT_DOWNLOAD, MSG_GET_SELECTION,
+    MSG_EXPORT_RESULT, MSG_EXPORT_MARKDOWN, MSG_SELECTION_CHANGED,
+} from '../messages';
+import type { DiffBlock, BlockSelection, ExportFrameResult } from '../exporter';
+```
+
+- [ ] **Step 2: Add DOM references**
+
+Add alongside existing DOM references:
+
+```typescript
+const exportNoSelection      = document.getElementById('export-no-selection') as HTMLElement;
+const exportFrameSummary     = document.getElementById('export-frame-summary') as HTMLElement;
+const exportFrameInfo        = document.getElementById('export-frame-info') as HTMLElement;
+const exportBlockCounts      = document.getElementById('export-block-counts') as HTMLElement;
+const exportTruncatedWarning = document.getElementById('export-truncated-warning') as HTMLElement;
+const exportBtn              = document.getElementById('export-btn') as HTMLButtonElement;
+const exportReviewBtn        = document.getElementById('export-review-btn') as HTMLButtonElement;
+const exportReviewPanel      = document.getElementById('export-review-panel') as HTMLElement;
+const exportReviewBreadcrumb = document.getElementById('export-review-breadcrumb') as HTMLElement;
+const exportReviewBlocks     = document.getElementById('export-review-blocks') as HTMLElement;
+const exportReviewBack       = document.getElementById('export-review-back') as HTMLButtonElement;
+const exportConfirmBtn       = document.getElementById('export-confirm-btn') as HTMLButtonElement;
+const exportLogPanel         = document.getElementById('export-log-panel') as HTMLElement;
+const exportLogContent       = document.getElementById('export-log-content') as HTMLElement;
+```
+
+- [ ] **Step 3: Add export state variables**
+
+```typescript
+let exportFrameResults: ExportFrameResult[] = [];
+let exportReviewSelections: Map<number, Map<number, boolean>> = new Map();
+let exportCurrentFrameIndex = 0;
+let pendingDownloadIndex = 0;
+```
+
+- [ ] **Step 4: Implement export UI helpers**
+
+Add the following functions to `ui.ts`. All innerHTML assignments use `escapeHtml()` on any user-provided text:
+
+```typescript
+function showExportNoSelection() {
+    exportNoSelection.hidden = false;
+    exportFrameSummary.hidden = true;
+    exportReviewPanel.hidden = true;
+}
+
+function renderExportSummary(frames: ExportFrameResult[]) {
+    exportFrameResults = frames;
+    exportReviewSelections = new Map();
+    exportNoSelection.hidden = true;
+    exportReviewPanel.hidden = true;
+
+    if (frames.length === 0) { showExportNoSelection(); return; }
+
+    exportFrameSummary.hidden = false;
+    const frame = frames[0];
+
+    exportFrameInfo.textContent = frames.length === 1
+        ? `"${frame.filename.replace('.md', '')}"`
+        : `${frames.length} frames selected`;
+
+    exportTruncatedWarning.hidden = !frame.sourceTruncated;
+
+    const unchanged = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'unchanged').length, 0);
+    const modified  = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'modified').length, 0);
+    const added     = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'new').length, 0);
+
+    if (!frame.hasStoredSource && frames.length === 1) {
+        exportBlockCounts.textContent = added === 0
+            ? 'No Markdown content detected. This frame may not use Markdown/* styles.'
+            : `${added} block${added !== 1 ? 's' : ''} inferred`;
+        exportBtn.disabled = added === 0;
+        exportReviewBtn.hidden = true;
+    } else {
+        const parts = [
+            unchanged > 0 ? `${unchanged} unchanged ✓` : '',
+            modified  > 0 ? `${modified} modified ↻`  : '',
+            added     > 0 ? `${added} added +`         : '',
+        ].filter(Boolean);
+        exportBlockCounts.textContent = parts.join('  ');
+        exportBtn.disabled = false;
+        exportBtn.textContent = frames.length > 1 ? `Export all (${frames.length} files)` : 'Export .md';
+        exportReviewBtn.hidden = (modified + added) === 0;
+    }
+}
+
+function renderReviewPanel(frameIndex: number) {
+    exportCurrentFrameIndex = frameIndex;
+    const frame = exportFrameResults[frameIndex];
+    if (!frame) return;
+
+    exportFrameSummary.hidden = true;
+    exportReviewPanel.hidden = false;
+
+    if (exportFrameResults.length > 1) {
+        exportReviewBreadcrumb.textContent = `Frame ${frameIndex + 1} of ${exportFrameResults.length}: ${frame.filename}`;
+        exportReviewBreadcrumb.hidden = false;
+    } else {
+        exportReviewBreadcrumb.hidden = true;
+    }
+
+    // Clear existing content using safe DOM method
+    while (exportReviewBlocks.firstChild) exportReviewBlocks.removeChild(exportReviewBlocks.firstChild);
+
+    const reviewable = frame.blocks.filter(b => b.state !== 'unchanged');
+    const frameSelections = exportReviewSelections.get(frameIndex) ?? new Map<number, boolean>();
+
+    reviewable.forEach(block => {
+        const blockIndex = frame.blocks.indexOf(block);
+        const defaultUseOriginal = block.state === 'modified';
+        const useOriginal = frameSelections.has(blockIndex) ? frameSelections.get(blockIndex)! : defaultUseOriginal;
+
+        const el = document.createElement('div');
+        el.className = `review-block review-block--${block.state}`;
+
+        // Header
+        const header = document.createElement('div');
+        header.className = 'review-block-header';
+        header.textContent = `${block.state === 'modified' ? '↻' : '+'} ${block.label} (${block.state})`;
+        el.appendChild(header);
+
+        // Fidelity warning (safe — static string from our code, not user input)
+        if (block.fidelityWarning) {
+            const warn = document.createElement('div');
+            warn.className = 'review-fidelity-warning';
+            warn.textContent = `⚠ ${block.fidelityWarning}`;
+            el.appendChild(warn);
+        }
+
+        // Diff panes
+        const diff = document.createElement('div');
+        diff.className = 'review-diff';
+
+        if (block.originalText !== undefined) {
+            const origCol = document.createElement('div');
+            origCol.className = 'review-diff-col';
+            const origLabel = document.createElement('div');
+            origLabel.className = 'review-diff-header';
+            origLabel.textContent = 'Original';
+            const origPre = document.createElement('pre');
+            origPre.className = 'review-diff-text';
+            origPre.textContent = block.originalText; // textContent is safe — no HTML injection
+            origCol.appendChild(origLabel);
+            origCol.appendChild(origPre);
+            diff.appendChild(origCol);
+        }
+
+        const currCol = document.createElement('div');
+        currCol.className = 'review-diff-col';
+        const currLabel = document.createElement('div');
+        currLabel.className = 'review-diff-header';
+        currLabel.textContent = 'Current';
+        const currPre = document.createElement('pre');
+        currPre.className = 'review-diff-text';
+        currPre.textContent = block.inferredText; // textContent is safe
+        currCol.appendChild(currLabel);
+        currCol.appendChild(currPre);
+        diff.appendChild(currCol);
+        el.appendChild(diff);
+
+        // Action buttons
+        const actions = document.createElement('div');
+        actions.className = 'review-block-actions';
+
+        const makeBtn = (label: string, blockIdx: number, useOrig: boolean, active: boolean) => {
+            const btn = document.createElement('button');
+            btn.className = `btn-review${active ? ' btn-review--active' : ''}`;
+            btn.textContent = label;
+            btn.addEventListener('click', () => {
+                const sel = exportReviewSelections.get(frameIndex) ?? new Map<number, boolean>();
+                sel.set(blockIdx, useOrig);
+                exportReviewSelections.set(frameIndex, sel);
+                renderReviewPanel(frameIndex);
+            });
+            return btn;
+        };
+
+        if (block.state === 'modified') {
+            actions.appendChild(makeBtn('✓ Keep original', blockIndex, true, useOriginal));
+            actions.appendChild(makeBtn('Use current', blockIndex, false, !useOriginal));
+        } else {
+            actions.appendChild(makeBtn('✓ Include', blockIndex, false, !useOriginal));
+            actions.appendChild(makeBtn('Skip', blockIndex, true, useOriginal));
+        }
+
+        el.appendChild(actions);
+        exportReviewBlocks.appendChild(el);
+    });
+}
+
+function triggerDownload(filename: string, content: string) {
+    const blob = new Blob([content], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function downloadFrame(frameIndex: number) {
+    const frame = exportFrameResults[frameIndex];
+    if (!frame) return;
+    const sel = exportReviewSelections.get(frameIndex);
+    const selections: BlockSelection[] = sel
+        ? Array.from(sel.entries()).map(([blockIndex, useOriginal]) => ({ blockIndex, useOriginal }))
+        : [];
+    parent.postMessage({ pluginMessage: { type: MSG_EXPORT_DOWNLOAD, frameId: frame.frameId, selections } }, '*');
+}
+
+function startSequentialDownload() {
+    pendingDownloadIndex = 0;
+    downloadFrame(pendingDownloadIndex);
+}
+
+function renderExportLog(frames: ExportFrameResult[]) {
+    const lines: string[] = [];
+    for (const frame of frames) {
+        if (frame.skippedLayers.length > 0) {
+            lines.push(`--- ${frame.filename} ---`);
+            for (const s of frame.skippedLayers) {
+                lines.push(`  Skipped: "${s.name}" — ${s.reason}`);
+            }
+        }
+    }
+    exportLogPanel.hidden = lines.length === 0;
+    exportLogContent.textContent = lines.join('\n');
+}
+```
+
+- [ ] **Step 5: Wire button event listeners**
+
+Add after the DOM reference declarations:
+
+```typescript
+exportBtn.addEventListener('click', startSequentialDownload);
+
+exportReviewBtn.addEventListener('click', () => renderReviewPanel(0));
+
+exportReviewBack.addEventListener('click', () => {
+    exportReviewPanel.hidden = true;
+    exportFrameSummary.hidden = false;
+});
+
+exportConfirmBtn.addEventListener('click', () => downloadFrame(exportCurrentFrameIndex));
+```
+
+- [ ] **Step 6: Handle incoming export messages**
+
+In the `window.onmessage` handler, add alongside `MSG_SETTINGS`, `MSG_STATUS`, etc.:
+
+```typescript
+if (msg.type === MSG_SELECTION_CHANGED) {
+    const activePanel = document.querySelector<HTMLElement>('.tab-panel:not([hidden])');
+    if (activePanel?.id === 'export-panel') {
+        if (msg.frameIds.length > 0) {
+            parent.postMessage({ pluginMessage: { type: MSG_EXPORT_REQUEST, frameIds: msg.frameIds } }, '*');
+        } else {
+            showExportNoSelection();
+        }
+    }
+    return;
+}
+
+if (msg.type === MSG_EXPORT_RESULT) {
+    renderExportSummary(msg.frames);
+    renderExportLog(msg.frames);
+    return;
+}
+
+if (msg.type === MSG_EXPORT_MARKDOWN) {
+    triggerDownload(msg.filename, msg.content);
+    pendingDownloadIndex++;
+    if (pendingDownloadIndex < exportFrameResults.length) {
+        setTimeout(() => downloadFrame(pendingDownloadIndex), 300);
+    }
+    return;
+}
+```
+
+- [ ] **Step 7: Trigger selection request when Export tab is activated**
+
+In the tab-switch handler (where `data-tab` is read), add for the `'export'` case:
+
+```typescript
+parent.postMessage({ pluginMessage: { type: MSG_GET_SELECTION } }, '*');
+```
+
+- [ ] **Step 8: Add export CSS to styles.css**
+
+```css
+/* ── Export Panel ─────────────────────────────────────────────────────────── */
+
+.export-empty {
+    padding: 24px 16px;
+    color: var(--figma-color-text-secondary, #666);
+    text-align: center;
+    font-size: 13px;
+}
+
+#export-frame-info {
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 8px;
+}
+
+#export-block-counts {
+    font-size: 12px;
+    margin-bottom: 16px;
+    color: var(--figma-color-text-secondary, #555);
+}
+
+.export-warning {
+    font-size: 12px;
+    color: #9a6700;
+    margin-bottom: 12px;
+}
+
+#export-actions {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+/* ── Review Mode ──────────────────────────────────────────────────────────── */
+
+.review-block {
+    border: 1px solid var(--figma-color-border, #e0e0e0);
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 12px;
+}
+
+.review-block--modified { border-left: 3px solid #9a6700; }
+.review-block--new      { border-left: 3px solid #0969da; }
+
+.review-block-header {
+    font-weight: 600;
+    font-size: 12px;
+    margin-bottom: 8px;
+}
+
+.review-fidelity-warning {
+    font-size: 11px;
+    color: #9a6700;
+    margin-bottom: 8px;
+}
+
+.review-diff {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.review-diff-col { flex: 1; min-width: 0; }
+
+.review-diff-header {
+    font-size: 11px;
+    color: #666;
+    margin-bottom: 4px;
+}
+
+.review-diff-text {
+    font-size: 11px;
+    font-family: 'Roboto Mono', monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: var(--figma-color-bg-secondary, #f5f5f5);
+    border-radius: 4px;
+    padding: 6px 8px;
+    margin: 0;
+}
+
+.review-block-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.btn-review {
+    font-size: 11px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--figma-color-border, #ccc);
+    background: transparent;
+    cursor: pointer;
+}
+
+.btn-review--active {
+    background: var(--figma-color-bg-brand, #18a0fb);
+    color: white;
+    border-color: transparent;
+}
+
+.btn-link {
+    background: none;
+    border: none;
+    color: var(--figma-color-text-brand, #0969da);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 0;
+    margin-top: 12px;
+    display: block;
+}
+
+#export-log-panel { margin-top: 16px; }
+#export-log-content { font-size: 11px; font-family: monospace; white-space: pre-wrap; }
+```
+
+- [ ] **Step 9: Build and manually verify in Figma**
+
+```bash
+npm run build
+```
+
+Manual test checklist:
+1. Select a previously-imported frame → Export tab shows block counts
+2. Click Export .md → `.md` file downloads with original source preserved
+3. Click Review changes → diff panel shows modified/new blocks with correct defaults
+4. Toggle a block selection → button highlight updates
+5. Click Export .md from review panel → download uses selected versions
+6. Select a non-plugin frame → "No import history found" message appears
+7. Select 0 frames → "Select one or more frames" empty state appears
+
+- [ ] **Step 10: Run all tests**
+
+```bash
+npx jest --verbose
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add figma-markdown-sync/src/ui.ts figma-markdown-sync/src/styles.css
+git commit -m "feat: implement Export tab UI with summary, review mode, and file download"
+```
+
+---
+
+## Chunk 5: Final Verification
+
+### Task 11: End-to-end test and cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd figma-markdown-sync && npx jest --verbose --coverage
+```
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 2: Build final plugin**
+
+```bash
+npm run build
+```
+Expected: no TypeScript errors or warnings.
+
+- [ ] **Step 3: End-to-end manual test in Figma**
+
+1. Import a `.md` file with headings, paragraphs, a code block, inline links, and a table
+2. Select the imported frame → open Export tab → verify unchanged/modified/added counts are correct
+3. Click Export .md → verify the downloaded file matches the original source exactly (inline links preserved)
+4. Edit a paragraph text node in the frame
+5. Re-select the frame → open Export tab → verify "1 modified" appears
+6. Click Review changes → verify the modified block shows original vs current with "Keep original" defaulted
+7. Switch to "Use current" → click Export .md → verify downloaded file uses the edited text
+8. Import 2 additional files → select all 3 frames → click Export tab → click Export all → verify 3 sequential `.md` downloads
+9. Select a frame never imported by this plugin → verify "No import history found" state and inference-only export
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: Figma → Markdown export — full pipeline complete"
+```
+
+---
+
+## Summary
+
+| Chunk | Tasks | Output |
+|-------|-------|--------|
+| 1: pluginData Storage | 1–4 | Frames store source at import; messages.ts has all export constants |
+| 2: Inference Engine | 5 | `exporter.ts` infers all 18 block types from layer tree |
+| 3: Diff + Assembly | 6–8 | Content-hash diff, Markdown assembly, sandbox handlers wired |
+| 4: Export Tab UI | 9–10 | Export tab, summary view, review mode, download trigger, CSS |
+| 5: Verification | 11 | Full test suite + end-to-end manual verification |

--- a/docs/superpowers/specs/2026-03-12-export-figma-to-markdown-design.md
+++ b/docs/superpowers/specs/2026-03-12-export-figma-to-markdown-design.md
@@ -1,0 +1,239 @@
+# Export: Figma → Markdown Design
+
+**Date:** 2026-03-12
+**Status:** Approved
+**Audience:** Designer using MarkDown For What as a personal workflow tool
+**Approach:** Hybrid diff-based export — automatic merge by default, selective review on demand
+
+---
+
+## Context
+
+MarkDown For What imports Markdown files into Figma as styled frames. This spec adds the reverse: exporting Figma frames back to `.md` files.
+
+The primary use case is round-tripping: a designer imports a spec, makes edits to the Figma frame, and wants to export the updated content back to Markdown without losing formatting that didn't survive the render (inline links, footnotes, badge syntax, Mermaid source).
+
+Two frame types exist in practice:
+- **Plugin-created frames** — imported via this plugin; have `pluginData` with the original Markdown source stored at import time
+- **Arbitrary frames** — any other Figma frame; no stored source; inference only
+
+---
+
+## Section 1: Architecture
+
+The export pipeline runs four stages in sequence:
+
+### Stage 1: Source detection
+Check the selected frame(s) for `pluginData` key `markdownSource`. If present, parse stored Markdown into a block array (same `Block[]` type used by the import pipeline). If absent, skip to Stage 2 with an empty source block array.
+
+### Stage 2: Layer-tree inference
+Always runs. Walks the frame's layer tree and produces an inferred `Block[]` array by mapping Figma layer properties to Markdown tokens.
+
+**Inference mapping rules:**
+
+| Figma signal | → Markdown output |
+|---|---|
+| Text node with style `Markdown/H1` | `# text` |
+| Text node with style `Markdown/H2` | `## text` |
+| Text node with style `Markdown/H3` | `### text` |
+| Text node with style `Markdown/Body` | paragraph |
+| Text node with style `Markdown/Code` | ` ``` \ntext\n``` ` |
+| Text node with style `Markdown/Quote` | `> text` |
+| Frame named `[hr]` | `---` |
+| Frame named `[table-*]` | reconstructed GFM table |
+| Image node | `![](placeholder)` with a fidelity warning |
+| Unknown layer | skipped; logged in export summary |
+
+For frames using **style binding** (custom styles via Settings), the plugin reads the stored `styleBindings` map from `pluginData` and uses those style IDs as signals in place of `Markdown/*` names.
+
+### Stage 3: Block-level diff
+Compare stored source blocks (Stage 1) against inferred blocks (Stage 2) to produce a diff result.
+
+**Match strategy:** blocks are matched by position and type. A heading at index 0 in source matches a heading at index 0 in the inferred array. Content is normalized (whitespace, punctuation) before comparison so only meaningful changes are flagged.
+
+**Three block states:**
+
+| State | Condition | Export output |
+|---|---|---|
+| `unchanged` | inferred content matches source (after normalization) | original source text — preserves inline links, footnotes, badge syntax, Mermaid source |
+| `modified` | same position and type, content differs | inferred output; fidelity warning shown if block had lossy elements |
+| `new` | no corresponding source block | inferred output |
+
+For frames with no `pluginData`, all blocks are `new` and the diff stage is skipped.
+
+### Stage 4: Assembly
+Merge the diff result into a final Markdown string. Export as:
+- Single frame → `.md` file download, named after the frame
+- Multiple frames → `.zip` containing one `.md` per frame
+
+---
+
+## Section 2: Diff Engine
+
+### Block fingerprinting
+Each block is fingerprinted by `type + normalizedContent`. Normalization strips leading/trailing whitespace and collapses internal whitespace runs to a single space.
+
+### Reordering
+If a block's type matches but its position has changed, it is treated as `modified` at its new position. No attempt is made to track moves — this keeps the diff simple and predictable.
+
+### Fidelity warnings
+A fidelity warning is attached to a `modified` or `new` block when the inferred output is known to be lossy. Lossy block types:
+- Paragraphs containing inline links (link URL lost; text preserved)
+- Paragraphs containing footnote references (reference markers lost)
+- Paragraphs containing badge syntax (rendered as plain text)
+- Mermaid blocks (source may be partially recoverable from a stored label layer, but not guaranteed)
+- Math/LaTeX blocks (same as Mermaid)
+
+Fidelity warnings are informational only — they do not block export.
+
+---
+
+## Section 3: Export UX
+
+### Export tab
+A new **Export** tab added to the plugin UI alongside Import, Preview, Settings, and History.
+
+**Plugin-created frame selected (with stored source):**
+```
+Export
+
+"my-design-spec"  · imported Mar 10
+
+3 blocks unchanged  ✓
+2 blocks modified   ↻
+1 block added       +
+
+[ Export .md ]   [ Review changes ]
+```
+
+`Export .md` exports the auto-merged result immediately — no friction for the common case.
+
+**Arbitrary frame selected (no stored source):**
+```
+Export
+
+"Random Frame"
+No import history found.
+
+6 blocks inferred
+2 layers skipped  ⚠
+
+[ Export .md ]   [ View export log ]
+```
+
+**No frame selected:**
+```
+Export
+
+Select one or more frames on the canvas
+to export them as Markdown.
+```
+
+---
+
+### Selective review mode
+
+Triggered by clicking **Review changes**. Shows only `modified` and `new` blocks. Each block displays an inline two-pane diff with an accept/reject control.
+
+**Modified block (with fidelity warning):**
+```
+↻  Paragraph  (modified)
+──────────────────────────────────────
+Original              │  Current
+See the [guide](url)  │  See the updated
+for more details.     │  guide for more
+                      │  details.
+                      │  ⚠ Link lost in export
+[ ✓ Keep original ]   [ Use current ]
+```
+
+**New block (no source equivalent):**
+```
++  Heading (added)
+──────────────────────────────────────
+"## New Section"
+
+[ ✓ Include ]   [ Skip ]
+```
+
+Default selections:
+- `modified`: Keep original (preserves fidelity)
+- `new`: Include (user added it, likely intentional)
+
+After reviewing, `Export .md` at the bottom of the panel exports the final merged result with user selections applied.
+
+---
+
+### Multi-frame export
+
+When multiple frames are selected:
+
+1. Summary view shows per-frame diff counts before export
+2. `Export .md` exports all frames immediately as a `.zip`
+3. `Review changes` steps through frames one at a time in the review panel
+4. Output zip uses frame names as filenames; conflicts are resolved by appending an index
+
+---
+
+### Export log
+
+After every export, a collapsible log panel shows:
+- Skipped layers (name + reason)
+- Fidelity warnings per block
+- Total block count and file size
+
+The log persists until the next export action. It is not added to Import History.
+
+---
+
+## Section 4: Data Storage
+
+### At import time (new behavior)
+When a frame is created by this plugin, store the original Markdown source:
+
+```typescript
+figma.currentPage.selection[0].setPluginData('markdownSource', markdownString)
+figma.currentPage.selection[0].setPluginData('markdownImportedAt', Date.now().toString())
+figma.currentPage.selection[0].setPluginData('markdownFilename', filename)
+```
+
+### At export time
+Read back:
+```typescript
+const source = frame.getPluginData('markdownSource')
+const importedAt = frame.getPluginData('markdownImportedAt')
+const filename = frame.getPluginData('markdownFilename')
+```
+
+### Existing frames (no pluginData)
+The export pipeline handles missing `pluginData` gracefully — falls back to inference-only with no error.
+
+---
+
+## Section 5: Architecture Impact
+
+**New file:** `figma-markdown-sync/exporter.ts` — layer-tree walker, inference rules, block diff engine, Markdown assembly
+
+**Modified files:**
+- `figma-markdown-sync/code.ts` — store `pluginData` on frame creation; handle `export-request` and `export-confirm` message types
+- `figma-markdown-sync/messages.ts` — add export message types
+- `figma-markdown-sync/ui.html` — Export tab
+- `figma-markdown-sync/src/ui.ts` — export tab logic, diff display, review mode, file download trigger
+- `figma-markdown-sync/src/styles.css` — export tab styles, diff view styles
+
+**New test file:** `figma-markdown-sync/exporter.test.ts` — inference rules, diff engine, assembly
+
+**No changes to:** `parser.ts`, `renderer.ts`, `blockRenderers.ts`, `styles.ts`, `settings.ts`, `tables.ts`
+
+---
+
+## Priority & Sequencing
+
+| Phase | Work | Complexity |
+|---|---|---|
+| 1 | Store `pluginData` at import time | Low |
+| 2 | Layer-tree inference (`exporter.ts`) | Medium |
+| 3 | Block-level diff engine | Medium |
+| 4 | Export tab UI (default auto-merge) | Medium |
+| 5 | Review mode UI (selective diff) | Medium |
+| 6 | Multi-frame + zip export | Low |

--- a/docs/superpowers/specs/2026-03-12-export-figma-to-markdown-design.md
+++ b/docs/superpowers/specs/2026-03-12-export-figma-to-markdown-design.md
@@ -31,6 +31,8 @@ Always runs. Walks the frame's layer tree and produces an inferred `Block[]` arr
 
 **Inference mapping rules:**
 
+The exporter identifies block types by matching against the actual layer names and node types produced by the renderer:
+
 | Figma signal | → Markdown output |
 |---|---|
 | Text node with style `Markdown/H1` | `# text` |
@@ -39,17 +41,29 @@ Always runs. Walks the frame's layer tree and produces an inferred `Block[]` arr
 | Text node with style `Markdown/Body` | paragraph |
 | Text node with style `Markdown/Code` | ` ``` \ntext\n``` ` |
 | Text node with style `Markdown/Quote` | `> text` |
-| Frame named `[hr]` | `---` |
-| Frame named `[table-*]` | reconstructed GFM table |
-| Image node | `![](placeholder)` with a fidelity warning |
+| `RectangleNode` with height = 1 | `---` (separator; identified by node type + height, not name) |
+| Frame named `'Table'` | reconstructed GFM table (walk child rows/cells) |
+| Frame named `'List Group'` | bullet list items (walk child text nodes) |
+| Frame named `'Callout: Note'` / `'Callout: Tip'` etc. | `> [!NOTE]` / `> [!TIP]` etc. |
+| Frame named `'Table of Contents'` | `toc` block — re-emits as a fidelity warning; TOC is auto-generated on re-import |
+| Frame named `'Definition List'` | `term\n: definition` pairs |
+| Frame named `'Footnotes'` | footnote section (walk child text nodes) |
+| Frame named `'Badge Row'` | `[badge:Label]` syntax per child pill |
+| Frame named `'Mermaid Diagram'` | ` ```mermaid\n...\n``` ` — source recovered from stored `pluginData` key `mermaidSource` if present, otherwise fidelity warning |
+| Frame named `'Math Block'` | `$$\n...\n$$` — source recovered from `pluginData` key `mathSource` if present, otherwise fidelity warning |
+| Image node (any `RECTANGLE` with `fills[0].type === 'IMAGE'`) | `![alt](placeholder)` with a fidelity warning (original URL not recoverable) |
 | Unknown layer | skipped; logged in export summary |
 
-For frames using **style binding** (custom styles via Settings), the plugin reads the stored `styleBindings` map from `pluginData` and uses those style IDs as signals in place of `Markdown/*` names.
+**componentNames mode:** When the import was done with `componentNames: true`, text nodes inside list groups are named `'Bullet/Item'`, `'Ordered/Item'`, etc. The exporter reads these names as secondary signals when the style-based signal is unavailable.
+
+For frames using **style binding** (custom text styles instead of `Markdown/*`), the exporter reads the `textStyleId` from each text node via `node.getTextStyleIdAsync()` and resolves the style name via `figma.getStyleByIdAsync(id)`. If the resolved name matches a bound element in the stored settings `styleBindings` map, that node is classified accordingly. This correctly handles the case where the user changed their style bindings between import and export.
 
 ### Stage 3: Block-level diff
 Compare stored source blocks (Stage 1) against inferred blocks (Stage 2) to produce a diff result.
 
-**Match strategy:** blocks are matched by position and type. A heading at index 0 in source matches a heading at index 0 in the inferred array. Content is normalized (whitespace, punctuation) before comparison so only meaningful changes are flagged.
+**Match strategy:** blocks are matched first by content-hash (type + normalized content fingerprint). If a block's fingerprint exists in both the source and inferred arrays, it is matched regardless of position — this handles most insertion/deletion cases. When no content match is found, position + type is used as a fallback. Content is normalized (whitespace, punctuation) before fingerprinting so minor edits are correctly flagged as `modified` rather than `new`.
+
+**Known limitation:** If a user edits the text of a block *and* inserts or removes other blocks, the edited block may not find a content match and will be treated as `modified` via position fallback. In these cases, the `unchanged` blocks on either side of the edit will still match correctly by content hash. The review mode surfaces per-block diffs so the user can verify.
 
 **Three block states:**
 
@@ -63,8 +77,8 @@ For frames with no `pluginData`, all blocks are `new` and the diff stage is skip
 
 ### Stage 4: Assembly
 Merge the diff result into a final Markdown string. Export as:
-- Single frame → `.md` file download, named after the frame
-- Multiple frames → `.zip` containing one `.md` per frame
+- Single frame → `.md` file download, named after the frame (from stored `markdownFilename` > frame name > `"export"`)
+- Multiple frames → sequential per-file downloads (one `.md` per frame triggered in sequence from the UI iframe). ZIP output is deferred — the Figma plugin sandbox has no ZIP API, and bundling JSZip adds ~100 KB to the plugin bundle. Sequential downloads cover the typical use case (2–5 files). ZIP can be added as an explicit dependency if user demand warrants it.
 
 ---
 
@@ -115,11 +129,17 @@ Export
 "Random Frame"
 No import history found.
 
+Inference works best on frames using
+Markdown/* text styles. Other frames
+may produce few or no blocks.
+
 6 blocks inferred
 2 layers skipped  ⚠
 
 [ Export .md ]   [ View export log ]
 ```
+
+If inference produces zero blocks: replace the block count with "No Markdown content detected. This frame may not use Markdown/* styles." and disable the `Export .md` button.
 
 **No frame selected:**
 ```
@@ -169,9 +189,15 @@ After reviewing, `Export .md` at the bottom of the panel exports the final merge
 When multiple frames are selected:
 
 1. Summary view shows per-frame diff counts before export
-2. `Export .md` exports all frames immediately as a `.zip`
-3. `Review changes` steps through frames one at a time in the review panel
-4. Output zip uses frame names as filenames; conflicts are resolved by appending an index
+2. `Export all` triggers sequential per-file downloads — one `.md` per frame, each download initiated after the previous resolves
+3. `Review changes` steps through frames one at a time in the review panel; a breadcrumb shows "Frame 2 of 5"
+4. Filenames: stored `markdownFilename` > frame name > `"export-{index}"`. Duplicate names get an appended index (e.g. `spec.md`, `spec-2.md`)
+
+### Review mode cancel behavior
+
+- Clicking away from the Review panel or switching frame selection: selections are preserved in memory for the current plugin session; a "Back to export" link restores the panel
+- Closing the plugin: all in-progress review selections are discarded (no persistence needed — the diff re-runs on next open)
+- No confirmation prompt is shown on cancel — the operation is non-destructive until `Export .md` is clicked
 
 ---
 
@@ -189,13 +215,16 @@ The log persists until the next export action. It is not added to Import History
 ## Section 4: Data Storage
 
 ### At import time (new behavior)
-When a frame is created by this plugin, store the original Markdown source:
+After `renderBlocks` resolves and returns a `RenderResult`, store the original Markdown source on the resulting frame. The call site is in `code.ts` inside the `MSG_IMPORT_BATCH` handler:
 
 ```typescript
-figma.currentPage.selection[0].setPluginData('markdownSource', markdownString)
-figma.currentPage.selection[0].setPluginData('markdownImportedAt', Date.now().toString())
-figma.currentPage.selection[0].setPluginData('markdownFilename', filename)
+const result = await renderBlocks(name, blocks, settings, targetNode)
+result.frame.setPluginData('markdownSource', markdownString)
+result.frame.setPluginData('markdownImportedAt', Date.now().toString())
+result.frame.setPluginData('markdownFilename', filename)
 ```
+
+**Size limit:** Before storing, check `markdownString.length`. If it exceeds 50,000 characters (~50 KB), skip storing and set a flag `markdownSourceTruncated: 'true'` instead. On export, if this flag is present, the export panel shows: "Source too large to store — using current state only." The inference path runs normally; the user is informed rather than silently degraded.
 
 ### At export time
 Read back:
@@ -214,9 +243,40 @@ The export pipeline handles missing `pluginData` gracefully — falls back to in
 
 **New file:** `figma-markdown-sync/exporter.ts` — layer-tree walker, inference rules, block diff engine, Markdown assembly
 
+**New message types** (following the pattern in `messages.ts`):
+
+| Message | Direction | Payload | Purpose |
+|---|---|---|---|
+| `export-request` | UI → sandbox | `{ frameIds: string[] }` | User clicks Export tab; sandbox runs inference + diff, returns result |
+| `export-result` | sandbox → UI | `{ frames: ExportFrameResult[] }` | Diff result per frame for display in export panel |
+| `export-download` | UI → sandbox | `{ frameId: string, selections: BlockSelection[] }` | User confirmed; sandbox assembles final Markdown and sends back string |
+| `export-markdown` | sandbox → UI | `{ filename: string, content: string }` | UI triggers file download |
+
+```typescript
+interface ExportFrameResult {
+  frameId: string
+  filename: string
+  hasStoredSource: boolean
+  sourceTruncated: boolean
+  blocks: ExportBlock[]
+}
+
+interface ExportBlock {
+  state: 'unchanged' | 'modified' | 'new'
+  originalText?: string   // stored source text (undefined for 'new')
+  inferredText: string
+  fidelityWarning?: string
+}
+
+interface BlockSelection {
+  blockIndex: number
+  useOriginal: boolean  // true = keep original source, false = use inferred
+}
+```
+
 **Modified files:**
-- `figma-markdown-sync/code.ts` — store `pluginData` on frame creation; handle `export-request` and `export-confirm` message types
-- `figma-markdown-sync/messages.ts` — add export message types
+- `figma-markdown-sync/code.ts` — store `pluginData` on frame creation; handle `export-request` and `export-download` message types
+- `figma-markdown-sync/messages.ts` — add export message type constants
 - `figma-markdown-sync/ui.html` — Export tab
 - `figma-markdown-sync/src/ui.ts` — export tab logic, diff display, review mode, file download trigger
 - `figma-markdown-sync/src/styles.css` — export tab styles, diff view styles
@@ -231,9 +291,9 @@ The export pipeline handles missing `pluginData` gracefully — falls back to in
 
 | Phase | Work | Complexity |
 |---|---|---|
-| 1 | Store `pluginData` at import time | Low |
-| 2 | Layer-tree inference (`exporter.ts`) | Medium |
-| 3 | Block-level diff engine | Medium |
-| 4 | Export tab UI (default auto-merge) | Medium |
-| 5 | Review mode UI (selective diff) | Medium |
-| 6 | Multi-frame + zip export | Low |
+| 1 | Store `pluginData` at import time; add `mermaidSource`/`mathSource` keys in block renderers | Low |
+| 2 | Layer-tree inference (`exporter.ts`) — all 18 block types | Medium |
+| 3 | Content-hash diff engine | Medium |
+| 4 | Export tab UI (default auto-merge, export log) | Medium |
+| 5 | Review mode UI (selective diff, cancel/back behavior) | Medium |
+| 6 | Multi-frame sequential download | Low |

--- a/figma-markdown-sync/blockRenderers.ts
+++ b/figma-markdown-sync/blockRenderers.ts
@@ -416,6 +416,7 @@ export async function renderMermaidBlock(block: Block): Promise<FrameNode> {
 
     mermaidFrame.appendChild(labelNode);
     mermaidFrame.appendChild(sourceNode);
+    mermaidFrame.setPluginData('mermaidSource', block.content ?? '');
     return mermaidFrame;
 }
 
@@ -452,6 +453,7 @@ export async function renderMathBlock(block: Block): Promise<FrameNode> {
     mathText.textAlignHorizontal = 'CENTER';
 
     mathFrame.appendChild(mathText);
+    mathFrame.setPluginData('mathSource', block.content ?? '');
     return mathFrame;
 }
 

--- a/figma-markdown-sync/code.test.ts
+++ b/figma-markdown-sync/code.test.ts
@@ -172,6 +172,35 @@ describe('MSG_EXPORT_REQUEST handler', () => {
         );
         expect(mockExportFrame).not.toHaveBeenCalled();
     });
+
+    it('skips missing frames and still sends export-result with found frames', async () => {
+        // Two frame IDs requested; only one exists
+        const foundFrame = { id: 'frame-1', type: 'FRAME', name: 'Found' };
+        (figma.currentPage as any).findOne = jest.fn()
+            .mockImplementationOnce(() => foundFrame)   // first call: found
+            .mockImplementationOnce(() => null);          // second call: not found
+
+        const mockResult: ExportFrameResult = {
+            frameId: 'frame-1',
+            filename: 'Found',
+            hasStoredSource: false,
+            sourceTruncated: false,
+            blocks: [],
+            skippedLayers: [],
+        };
+        mockExportFrame.mockResolvedValueOnce(mockResult);
+
+        await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: ['frame-1', 'frame-missing'] });
+
+        // Should have sent an error status for the missing frame
+        expect(figma.ui.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: MSG_STATUS, error: true })
+        );
+        // But should still send export-result with the found frames
+        expect(figma.ui.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: MSG_EXPORT_RESULT, frames: [mockResult] })
+        );
+    });
 });
 
 // ─── MSG_EXPORT_DOWNLOAD handler ──────────────────────────────────────────────

--- a/figma-markdown-sync/code.test.ts
+++ b/figma-markdown-sync/code.test.ts
@@ -63,6 +63,8 @@ beforeEach(() => {
     (figma.currentPage as any).selection = [];
     // Reset findOne to return null by default
     (figma.currentPage as any).findOne = jest.fn(() => null);
+    // Reset findAllWithCriteria to return empty array by default
+    (figma.currentPage as any).findAllWithCriteria = jest.fn(() => []);
 });
 
 // ─── selectionchange listener ─────────────────────────────────────────────────
@@ -138,9 +140,7 @@ describe('MSG_GET_SELECTION handler', () => {
 describe('MSG_EXPORT_REQUEST handler', () => {
     it('calls exportFrame for each frameId and posts export-result', async () => {
         const mockFrame = { type: 'FRAME', id: 'frame-1', name: 'My Frame' };
-        (figma.currentPage as any).findOne = jest.fn((pred: (n: any) => boolean) =>
-            pred(mockFrame) ? mockFrame : null
-        );
+        (figma.currentPage as any).findAllWithCriteria = jest.fn(() => [mockFrame]);
 
         const fakeResult: ExportFrameResult = {
             frameId: 'frame-1',
@@ -162,7 +162,8 @@ describe('MSG_EXPORT_REQUEST handler', () => {
     });
 
     it('posts error status if frameId not found', async () => {
-        (figma.currentPage as any).findOne = jest.fn(() => null);
+        // findAllWithCriteria returns empty — no frames on page
+        (figma.currentPage as any).findAllWithCriteria = jest.fn(() => []);
 
         await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: ['nonexistent-id'] });
 
@@ -174,11 +175,9 @@ describe('MSG_EXPORT_REQUEST handler', () => {
     });
 
     it('skips missing frames and still sends export-result with found frames', async () => {
-        // Two frame IDs requested; only one exists
+        // Two frame IDs requested; only one exists on the page
         const foundFrame = { id: 'frame-1', type: 'FRAME', name: 'Found' };
-        (figma.currentPage as any).findOne = jest.fn()
-            .mockImplementationOnce(() => foundFrame)   // first call: found
-            .mockImplementationOnce(() => null);          // second call: not found
+        (figma.currentPage as any).findAllWithCriteria = jest.fn(() => [foundFrame]);
 
         const mockResult: ExportFrameResult = {
             frameId: 'frame-1',
@@ -206,19 +205,9 @@ describe('MSG_EXPORT_REQUEST handler', () => {
 // ─── MSG_EXPORT_DOWNLOAD handler ──────────────────────────────────────────────
 
 describe('MSG_EXPORT_DOWNLOAD handler', () => {
-    it('calls assembleMarkdown with selections and posts export-markdown', async () => {
-        const mockFrame = {
-            type: 'FRAME',
-            id: 'frame-dl',
-            name: 'Download Frame',
-            _pluginData: { markdownSource: '# Hello', markdownFilename: 'hello.md' },
-            getPluginData: jest.fn(function(this: any, key: string) {
-                return this._pluginData[key] ?? '';
-            }),
-        };
-        (figma.currentPage as any).findOne = jest.fn((pred: (n: any) => boolean) =>
-            pred(mockFrame) ? mockFrame : null
-        );
+    it('uses cached export result and assembles markdown without re-inferring', async () => {
+        const mockFrame = { type: 'FRAME', id: 'frame-dl', name: 'Download Frame' };
+        (figma.currentPage as any).findAllWithCriteria = jest.fn(() => [mockFrame]);
 
         const fakeResult: ExportFrameResult = {
             frameId: 'frame-dl',
@@ -233,15 +222,16 @@ describe('MSG_EXPORT_DOWNLOAD handler', () => {
         const assembled = '# Hello\n\nSome content';
         mockAssembleMarkdown.mockReturnValue(assembled);
 
+        // Populate cache via MSG_EXPORT_REQUEST first
+        await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: ['frame-dl'] });
+        jest.clearAllMocks(); // clear postMessage calls so we can assert only download messages
+        mockAssembleMarkdown.mockReturnValue(assembled);
+
         const selections: BlockSelection[] = [{ blockIndex: 0, useOriginal: true }];
+        await sendMessage({ type: MSG_EXPORT_DOWNLOAD, frameId: 'frame-dl', selections });
 
-        await sendMessage({
-            type: MSG_EXPORT_DOWNLOAD,
-            frameId: 'frame-dl',
-            selections,
-        });
-
-        expect(mockExportFrame).toHaveBeenCalledWith(mockFrame);
+        // exportFrame should NOT be called again — cache hit
+        expect(mockExportFrame).not.toHaveBeenCalled();
         expect(mockAssembleMarkdown).toHaveBeenCalledWith(fakeResult.blocks, selections);
         expect(figma.ui.postMessage).toHaveBeenCalledWith({
             type: MSG_EXPORT_MARKDOWN,

--- a/figma-markdown-sync/code.test.ts
+++ b/figma-markdown-sync/code.test.ts
@@ -145,8 +145,7 @@ describe('MSG_EXPORT_REQUEST handler', () => {
         const fakeResult: ExportFrameResult = {
             frameId: 'frame-1',
             filename: 'my-frame.md',
-            hasStoredSource: false,
-            sourceTruncated: false,
+            sourceStatus: 'none',
             blocks: [],
             skippedLayers: [],
         };
@@ -182,8 +181,7 @@ describe('MSG_EXPORT_REQUEST handler', () => {
         const mockResult: ExportFrameResult = {
             frameId: 'frame-1',
             filename: 'Found',
-            hasStoredSource: false,
-            sourceTruncated: false,
+            sourceStatus: 'none',
             blocks: [],
             skippedLayers: [],
         };
@@ -212,8 +210,7 @@ describe('MSG_EXPORT_DOWNLOAD handler', () => {
         const fakeResult: ExportFrameResult = {
             frameId: 'frame-dl',
             filename: 'hello.md',
-            hasStoredSource: true,
-            sourceTruncated: false,
+            sourceStatus: 'present',
             blocks: [{ state: 'unchanged', originalText: '# Hello', inferredText: '# Hello' }],
             skippedLayers: [],
         };
@@ -227,7 +224,7 @@ describe('MSG_EXPORT_DOWNLOAD handler', () => {
         jest.clearAllMocks(); // clear postMessage calls so we can assert only download messages
         mockAssembleMarkdown.mockReturnValue(assembled);
 
-        const selections: BlockSelection[] = [{ blockIndex: 0, useOriginal: true }];
+        const selections: BlockSelection[] = [{ blockIndex: 0, action: 'use-original' }];
         await sendMessage({ type: MSG_EXPORT_DOWNLOAD, frameId: 'frame-dl', selections });
 
         // exportFrame should NOT be called again — cache hit
@@ -253,6 +250,84 @@ describe('MSG_EXPORT_DOWNLOAD handler', () => {
         expect(msgs).toContainEqual(
             expect.objectContaining({ type: MSG_STATUS, error: true })
         );
+        expect(mockExportFrame).not.toHaveBeenCalled();
+    });
+
+    it('calls exportFrame and assembles markdown when cache miss but frame is found', async () => {
+        const frameId = 'frame-1';
+        const mockResult: ExportFrameResult = {
+            frameId,
+            filename: 'my-doc.md',
+            sourceStatus: 'present',
+            blocks: [{ state: 'new', inferredText: '# Hello' }],
+            skippedLayers: [],
+        };
+        mockExportFrame.mockResolvedValue(mockResult);
+        mockAssembleMarkdown.mockReturnValue('# Hello');
+
+        // No prior MSG_EXPORT_REQUEST — cache is empty
+        // Set up findOne to return a frame
+        (figma.currentPage as any).findOne = jest.fn().mockReturnValue({ id: frameId, name: 'my-doc', type: 'FRAME' });
+
+        await sendMessage({ type: MSG_EXPORT_DOWNLOAD, frameId, selections: [] });
+
+        expect(mockExportFrame).toHaveBeenCalledTimes(1);
+        const posted = (figma.ui.postMessage as jest.Mock).mock.calls.find(
+            c => c[0].type === MSG_EXPORT_MARKDOWN
+        );
+        expect(posted).toBeDefined();
+        expect(posted[0].filename).toBe('my-doc.md');
+        expect(posted[0].content).toBe('# Hello');
+    });
+});
+
+// ─── MSG_EXPORT_REQUEST handler — additional cases ────────────────────────────
+
+describe('MSG_EXPORT_REQUEST handler — additional cases', () => {
+    it('posts MSG_STATUS error for each frame where exportFrame rejects, but still sends MSG_EXPORT_RESULT', async () => {
+        const goodFrameId = 'frame-good';
+        const badFrameId  = 'frame-bad';
+
+        const mockGoodResult: ExportFrameResult = {
+            frameId: goodFrameId,
+            filename: 'good.md',
+            sourceStatus: 'none',
+            blocks: [{ state: 'new', inferredText: '# Good' }],
+            skippedLayers: [],
+        };
+        (figma.currentPage as any).findAllWithCriteria = jest.fn().mockReturnValue([
+            { id: goodFrameId, name: 'good', type: 'FRAME' },
+            { id: badFrameId,  name: 'bad',  type: 'FRAME' },
+        ]);
+        mockExportFrame
+            .mockResolvedValueOnce(mockGoodResult)
+            .mockRejectedValueOnce(new Error('Figma API failure'));
+
+        await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: [goodFrameId, badFrameId] });
+
+        const statusMessages = (figma.ui.postMessage as jest.Mock).mock.calls.filter(
+            c => c[0].type === MSG_STATUS && c[0].error
+        );
+        expect(statusMessages.length).toBeGreaterThanOrEqual(1);
+        expect(statusMessages.some((c: any[]) => c[0].message.includes('bad'))).toBe(true);
+
+        const resultMsg = (figma.ui.postMessage as jest.Mock).mock.calls.find(
+            c => c[0].type === MSG_EXPORT_RESULT
+        );
+        expect(resultMsg).toBeDefined();
+        expect(resultMsg[0].frames).toHaveLength(1);
+        expect(resultMsg[0].frames[0].frameId).toBe(goodFrameId);
+    });
+
+    it('sends MSG_EXPORT_RESULT with empty frames array for empty frameIds', async () => {
+        (figma.currentPage as any).findAllWithCriteria = jest.fn().mockReturnValue([]);
+        await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: [] });
+
+        const resultMsg = (figma.ui.postMessage as jest.Mock).mock.calls.find(
+            c => c[0].type === MSG_EXPORT_RESULT
+        );
+        expect(resultMsg).toBeDefined();
+        expect(resultMsg[0].frames).toEqual([]);
         expect(mockExportFrame).not.toHaveBeenCalled();
     });
 });

--- a/figma-markdown-sync/code.test.ts
+++ b/figma-markdown-sync/code.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for code.ts message handlers.
+ *
+ * The IIFE in code.ts runs immediately on import and registers handlers on
+ * figma.ui.onmessage and figma.on('selectionchange', ...). We import code.ts
+ * once and then drive behaviour by calling figma.ui.onmessage / the
+ * selectionchange listener directly.
+ */
+
+import { ExportFrameResult, BlockSelection } from './exporter';
+import {
+    MSG_GET_SELECTION, MSG_SELECTION_CHANGED,
+    MSG_EXPORT_REQUEST, MSG_EXPORT_RESULT,
+    MSG_EXPORT_DOWNLOAD, MSG_EXPORT_MARKDOWN,
+    MSG_STATUS,
+} from './messages';
+
+// ─── Mock exporter before importing code.ts ──────────────────────────────────
+
+const mockExportFrame = jest.fn<Promise<ExportFrameResult>, [any]>();
+const mockAssembleMarkdown = jest.fn<string, [any, any]>();
+
+jest.mock('./exporter', () => ({
+    ...jest.requireActual('./exporter'),
+    exportFrame: (frame: any) => mockExportFrame(frame),
+    assembleMarkdown: (blocks: any, selections: any) => mockAssembleMarkdown(blocks, selections),
+}));
+
+// ─── Import code.ts (runs the IIFE) ──────────────────────────────────────────
+
+// Capture the selectionchange callback before jest.clearAllMocks() erases it.
+// code.ts registers via figma.on() at module-load time inside the IIFE.
+let selectionChangeCallback: (() => void) | null = null;
+(figma as any).on = jest.fn((event: string, cb: () => void) => {
+    if (event === 'selectionchange') selectionChangeCallback = cb;
+});
+
+import './code';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Dispatch a message through the registered onmessage handler. */
+async function sendMessage(msg: Record<string, any>): Promise<void> {
+    await (figma.ui as any).onmessage(msg);
+}
+
+/** Return all postMessage calls since the last jest.clearAllMocks(). */
+function postedMessages(): any[] {
+    return (figma.ui.postMessage as jest.Mock).mock.calls.map(c => c[0]);
+}
+
+/** Invoke the selectionchange callback registered by code.ts. */
+function fireSelectionChange(): void {
+    if (!selectionChangeCallback) throw new Error('selectionchange listener not registered');
+    selectionChangeCallback();
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset selection to empty by default
+    (figma.currentPage as any).selection = [];
+    // Reset findOne to return null by default
+    (figma.currentPage as any).findOne = jest.fn(() => null);
+});
+
+// ─── selectionchange listener ─────────────────────────────────────────────────
+
+describe('selectionchange listener', () => {
+    it('posts selection-changed with empty array when nothing is selected', () => {
+        (figma.currentPage as any).selection = [];
+        fireSelectionChange();
+        const msgs = postedMessages();
+        expect(msgs).toContainEqual({ type: MSG_SELECTION_CHANGED, frameIds: [] });
+    });
+
+    it('posts selection-changed with frame IDs for selected FRAME nodes', () => {
+        (figma.currentPage as any).selection = [
+            { type: 'FRAME', id: 'frame-1' },
+            { type: 'FRAME', id: 'frame-2' },
+        ];
+        fireSelectionChange();
+        const msgs = postedMessages();
+        expect(msgs).toContainEqual({ type: MSG_SELECTION_CHANGED, frameIds: ['frame-1', 'frame-2'] });
+    });
+
+    it('filters out non-FRAME nodes', () => {
+        (figma.currentPage as any).selection = [
+            { type: 'TEXT', id: 'text-1' },
+            { type: 'FRAME', id: 'frame-1' },
+        ];
+        fireSelectionChange();
+        const msgs = postedMessages();
+        expect(msgs).toContainEqual({ type: MSG_SELECTION_CHANGED, frameIds: ['frame-1'] });
+    });
+});
+
+// ─── MSG_GET_SELECTION handler ────────────────────────────────────────────────
+
+describe('MSG_GET_SELECTION handler', () => {
+    it('posts selection-changed with empty array when nothing is selected', async () => {
+        (figma.currentPage as any).selection = [];
+        await sendMessage({ type: MSG_GET_SELECTION });
+        expect(figma.ui.postMessage).toHaveBeenCalledWith({
+            type: MSG_SELECTION_CHANGED,
+            frameIds: [],
+        });
+    });
+
+    it('posts selection-changed with frame IDs for selected frames', async () => {
+        (figma.currentPage as any).selection = [
+            { type: 'FRAME', id: 'frame-a' },
+            { type: 'FRAME', id: 'frame-b' },
+        ];
+        await sendMessage({ type: MSG_GET_SELECTION });
+        expect(figma.ui.postMessage).toHaveBeenCalledWith({
+            type: MSG_SELECTION_CHANGED,
+            frameIds: ['frame-a', 'frame-b'],
+        });
+    });
+
+    it('filters out non-FRAME nodes from selection', async () => {
+        (figma.currentPage as any).selection = [
+            { type: 'TEXT', id: 'text-1' },
+            { type: 'FRAME', id: 'frame-1' },
+        ];
+        await sendMessage({ type: MSG_GET_SELECTION });
+        expect(figma.ui.postMessage).toHaveBeenCalledWith({
+            type: MSG_SELECTION_CHANGED,
+            frameIds: ['frame-1'],
+        });
+    });
+});
+
+// ─── MSG_EXPORT_REQUEST handler ───────────────────────────────────────────────
+
+describe('MSG_EXPORT_REQUEST handler', () => {
+    it('calls exportFrame for each frameId and posts export-result', async () => {
+        const mockFrame = { type: 'FRAME', id: 'frame-1', name: 'My Frame' };
+        (figma.currentPage as any).findOne = jest.fn((pred: (n: any) => boolean) =>
+            pred(mockFrame) ? mockFrame : null
+        );
+
+        const fakeResult: ExportFrameResult = {
+            frameId: 'frame-1',
+            filename: 'my-frame.md',
+            hasStoredSource: false,
+            sourceTruncated: false,
+            blocks: [],
+            skippedLayers: [],
+        };
+        mockExportFrame.mockResolvedValue(fakeResult);
+
+        await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: ['frame-1'] });
+
+        expect(mockExportFrame).toHaveBeenCalledWith(mockFrame);
+        expect(figma.ui.postMessage).toHaveBeenCalledWith({
+            type: MSG_EXPORT_RESULT,
+            frames: [fakeResult],
+        });
+    });
+
+    it('posts error status if frameId not found', async () => {
+        (figma.currentPage as any).findOne = jest.fn(() => null);
+
+        await sendMessage({ type: MSG_EXPORT_REQUEST, frameIds: ['nonexistent-id'] });
+
+        const msgs = postedMessages();
+        expect(msgs).toContainEqual(
+            expect.objectContaining({ type: MSG_STATUS, error: true })
+        );
+        expect(mockExportFrame).not.toHaveBeenCalled();
+    });
+});
+
+// ─── MSG_EXPORT_DOWNLOAD handler ──────────────────────────────────────────────
+
+describe('MSG_EXPORT_DOWNLOAD handler', () => {
+    it('calls assembleMarkdown with selections and posts export-markdown', async () => {
+        const mockFrame = {
+            type: 'FRAME',
+            id: 'frame-dl',
+            name: 'Download Frame',
+            _pluginData: { markdownSource: '# Hello', markdownFilename: 'hello.md' },
+            getPluginData: jest.fn(function(this: any, key: string) {
+                return this._pluginData[key] ?? '';
+            }),
+        };
+        (figma.currentPage as any).findOne = jest.fn((pred: (n: any) => boolean) =>
+            pred(mockFrame) ? mockFrame : null
+        );
+
+        const fakeResult: ExportFrameResult = {
+            frameId: 'frame-dl',
+            filename: 'hello.md',
+            hasStoredSource: true,
+            sourceTruncated: false,
+            blocks: [{ state: 'unchanged', originalText: '# Hello', inferredText: '# Hello' }],
+            skippedLayers: [],
+        };
+        mockExportFrame.mockResolvedValue(fakeResult);
+
+        const assembled = '# Hello\n\nSome content';
+        mockAssembleMarkdown.mockReturnValue(assembled);
+
+        const selections: BlockSelection[] = [{ blockIndex: 0, useOriginal: true }];
+
+        await sendMessage({
+            type: MSG_EXPORT_DOWNLOAD,
+            frameId: 'frame-dl',
+            selections,
+        });
+
+        expect(mockExportFrame).toHaveBeenCalledWith(mockFrame);
+        expect(mockAssembleMarkdown).toHaveBeenCalledWith(fakeResult.blocks, selections);
+        expect(figma.ui.postMessage).toHaveBeenCalledWith({
+            type: MSG_EXPORT_MARKDOWN,
+            filename: 'hello.md',
+            content: assembled,
+        });
+    });
+
+    it('posts error status if frameId not found', async () => {
+        (figma.currentPage as any).findOne = jest.fn(() => null);
+
+        await sendMessage({
+            type: MSG_EXPORT_DOWNLOAD,
+            frameId: 'missing-frame',
+            selections: [],
+        });
+
+        const msgs = postedMessages();
+        expect(msgs).toContainEqual(
+            expect.objectContaining({ type: MSG_STATUS, error: true })
+        );
+        expect(mockExportFrame).not.toHaveBeenCalled();
+    });
+});

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -14,6 +14,9 @@ import {
     MSG_GET_SELECTION, MSG_SELECTION_CHANGED,
 } from './messages';
 
+// Max Markdown source size stored as pluginData (~50 KB — Figma's practical limit)
+const MAX_MARKDOWN_SOURCE_SIZE = 50_000;
+
 // Initialize UI — 400×500 px panel, Figma Design only (not FigJam or Slides)
 figma.showUI(__html__, { width: 400, height: 500 });
 
@@ -23,6 +26,9 @@ figma.showUI(__html__, { width: 400, height: 500 });
         figma.closePlugin('MarkDown For What only supports Figma Design — not FigJam or Slides.');
         return;
     }
+
+    // Cache export results by frameId — reused by MSG_EXPORT_DOWNLOAD to avoid re-inferring
+    const exportResultCache = new Map<string, ExportFrameResult>();
 
     // Notify UI whenever the Figma selection changes
     figma.on('selectionchange', () => {
@@ -175,8 +181,8 @@ figma.showUI(__html__, { width: 400, height: 500 });
                     const result: RenderResult = await renderBlocks(nameNoExt, blocks, settings, target as SceneNode);
                     updatedCount++;
                     totalImageFailures += result.imageFailures;
-                    // Store source for round-trip export. Skip if > 50 KB to avoid pluginData limits.
-                    if (file.content.length <= 50_000) {
+                    // Store source for round-trip export. Skip if > MAX_MARKDOWN_SOURCE_SIZE to avoid pluginData limits.
+                    if (file.content.length <= MAX_MARKDOWN_SOURCE_SIZE) {
                         result.frame.setPluginData('markdownSource', file.content);
                         result.frame.setPluginData('markdownFilename', file.name);
                         result.frame.setPluginData('markdownImportedAt', Date.now().toString());
@@ -222,14 +228,20 @@ figma.showUI(__html__, { width: 400, height: 500 });
 
         if (msg.type === MSG_EXPORT_REQUEST) {
             const frameIds: string[] = msg.frameIds ?? [];
+            // One findAll scan + Map lookup — O(M + N) vs O(N × M) for repeated findOne
+            const allFrames = figma.currentPage.findAllWithCriteria({ types: ['FRAME'] }) as FrameNode[];
+            const frameMap = new Map(allFrames.map(n => [n.id, n]));
+            exportResultCache.clear();
             const frames: ExportFrameResult[] = [];
             for (const frameId of frameIds) {
-                const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
+                const node = frameMap.get(frameId) ?? null;
                 if (!node) {
                     figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
                     continue;
                 }
-                frames.push(await exportFrame(node));
+                const result = await exportFrame(node);
+                exportResultCache.set(frameId, result);
+                frames.push(result);
             }
             figma.ui.postMessage({ type: MSG_EXPORT_RESULT, frames });
             return;
@@ -238,14 +250,21 @@ figma.showUI(__html__, { width: 400, height: 500 });
         if (msg.type === MSG_EXPORT_DOWNLOAD) {
             const frameId: string = msg.frameId;
             const selections: BlockSelection[] = msg.selections ?? [];
-            const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
-            if (!node) {
-                figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
+            // Reuse cached result from MSG_EXPORT_REQUEST to avoid re-inferring the layer tree
+            const cached = exportResultCache.get(frameId);
+            if (!cached) {
+                const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
+                if (!node) {
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
+                    return;
+                }
+                const result = await exportFrame(node);
+                const content = assembleMarkdown(result.blocks, selections);
+                figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: result.filename, content });
                 return;
             }
-            const result = await exportFrame(node);
-            const content = assembleMarkdown(result.blocks, selections);
-            figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: result.filename, content });
+            const content = assembleMarkdown(cached.blocks, selections);
+            figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: cached.filename, content });
             return;
         }
     } catch (err) {

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -209,6 +209,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 message: statusMessage,
                 error: failedCount > 0
             });
+            return;
         }
 
         if (msg.type === MSG_GET_SELECTION) {

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -3,11 +3,15 @@ import { DEFAULT_SETTINGS, loadSettings, saveSettings, loadHistory, recordImport
 import { loadFont } from './styles';
 import { renderBlocks, RenderResult } from './renderer';
 import { errorMessage } from './utils';
+import { exportFrame, assembleMarkdown, ExportFrameResult, BlockSelection } from './exporter';
 import {
     MSG_GET_SETTINGS, MSG_SAVE_SETTINGS, MSG_RESET_SETTINGS,
     MSG_GET_LOCAL_STYLES, MSG_GET_LOCAL_COMPONENTS,
     MSG_GET_HISTORY, MSG_CLEAR_HISTORY, MSG_IMPORT_BATCH,
     MSG_STATUS, MSG_SETTINGS, MSG_LOCAL_STYLES, MSG_LOCAL_COMPONENTS, MSG_HISTORY,
+    MSG_EXPORT_REQUEST, MSG_EXPORT_RESULT,
+    MSG_EXPORT_DOWNLOAD, MSG_EXPORT_MARKDOWN,
+    MSG_GET_SELECTION, MSG_SELECTION_CHANGED,
 } from './messages';
 
 // Initialize UI — 400×500 px panel, Figma Design only (not FigJam or Slides)
@@ -19,6 +23,14 @@ figma.showUI(__html__, { width: 400, height: 500 });
         figma.closePlugin('MarkDown For What only supports Figma Design — not FigJam or Slides.');
         return;
     }
+
+    // Notify UI whenever the Figma selection changes
+    figma.on('selectionchange', () => {
+        const frameIds = figma.currentPage.selection
+            .filter((n: SceneNode) => n.type === 'FRAME')
+            .map((n: SceneNode) => n.id);
+        figma.ui.postMessage({ type: MSG_SELECTION_CHANGED, frameIds });
+    });
 
     // Message handler — see messages.ts for all supported message types
     figma.ui.onmessage = async (msg) => {
@@ -197,6 +209,43 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 message: statusMessage,
                 error: failedCount > 0
             });
+        }
+
+        if (msg.type === MSG_GET_SELECTION) {
+            const frameIds = figma.currentPage.selection
+                .filter((n: SceneNode) => n.type === 'FRAME')
+                .map((n: SceneNode) => n.id);
+            figma.ui.postMessage({ type: MSG_SELECTION_CHANGED, frameIds });
+            return;
+        }
+
+        if (msg.type === MSG_EXPORT_REQUEST) {
+            const frameIds: string[] = msg.frameIds ?? [];
+            const frames: ExportFrameResult[] = [];
+            for (const frameId of frameIds) {
+                const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
+                if (!node) {
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
+                    return;
+                }
+                frames.push(await exportFrame(node));
+            }
+            figma.ui.postMessage({ type: MSG_EXPORT_RESULT, frames });
+            return;
+        }
+
+        if (msg.type === MSG_EXPORT_DOWNLOAD) {
+            const frameId: string = msg.frameId;
+            const selections: BlockSelection[] = msg.selections ?? [];
+            const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
+            if (!node) {
+                figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
+                return;
+            }
+            const result = await exportFrame(node);
+            const content = assembleMarkdown(result.blocks, selections);
+            figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: result.filename, content });
+            return;
         }
     } catch (err) {
         console.error('[MarkDown For What] Unhandled error in message handler:', err);

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -27,15 +27,20 @@ figma.showUI(__html__, { width: 400, height: 500 });
         return;
     }
 
-    // Cache export results by frameId — reused by MSG_EXPORT_DOWNLOAD to avoid re-inferring
+    // Cache export results by frameId — reused by MSG_EXPORT_DOWNLOAD to avoid re-inferring.
+    // Cleared at the start of each MSG_EXPORT_REQUEST to prevent stale results after selection changes.
     const exportResultCache = new Map<string, ExportFrameResult>();
 
     // Notify UI whenever the Figma selection changes
     figma.on('selectionchange', () => {
-        const frameIds = figma.currentPage.selection
-            .filter((n: SceneNode) => n.type === 'FRAME')
-            .map((n: SceneNode) => n.id);
-        figma.ui.postMessage({ type: MSG_SELECTION_CHANGED, frameIds });
+        try {
+            const frameIds = figma.currentPage.selection
+                .filter((n: SceneNode) => n.type === 'FRAME')
+                .map((n: SceneNode) => n.id);
+            figma.ui.postMessage({ type: MSG_SELECTION_CHANGED, frameIds });
+        } catch (err) {
+            console.error('[MarkDown For What] selectionchange handler error:', err);
+        }
     });
 
     // Message handler — see messages.ts for all supported message types
@@ -187,6 +192,8 @@ figma.showUI(__html__, { width: 400, height: 500 });
                         result.frame.setPluginData('markdownFilename', file.name);
                         result.frame.setPluginData('markdownImportedAt', Date.now().toString());
                     } else {
+                        // If content exceeds MAX_MARKDOWN_SOURCE_SIZE, record that the source was too large
+                        // but do not store content. All blocks will be marked 'new' on export.
                         result.frame.setPluginData('markdownSourceTruncated', 'true');
                     }
                     // Record in import history (fire-and-forget — don't block render)
@@ -236,12 +243,16 @@ figma.showUI(__html__, { width: 400, height: 500 });
             for (const frameId of frameIds) {
                 const node = frameMap.get(frameId) ?? null;
                 if (!node) {
-                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true, domain: 'export' });
                     continue;
                 }
-                const result = await exportFrame(node);
-                exportResultCache.set(frameId, result);
-                frames.push(result);
+                try {
+                    const result = await exportFrame(node);
+                    exportResultCache.set(frameId, result);
+                    frames.push(result);
+                } catch (e) {
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Failed to export frame "${node.name}": ${errorMessage(e)}`, error: true, domain: 'export' });
+                }
             }
             figma.ui.postMessage({ type: MSG_EXPORT_RESULT, frames });
             return;
@@ -255,7 +266,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
             if (!cached) {
                 const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
                 if (!node) {
-                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true, domain: 'export' });
                     return;
                 }
                 const result = await exportFrame(node);

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -227,7 +227,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
                 if (!node) {
                     figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true });
-                    return;
+                    continue;
                 }
                 frames.push(await exportFrame(node));
             }

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -12,6 +12,7 @@ import {
     MSG_EXPORT_REQUEST, MSG_EXPORT_RESULT,
     MSG_EXPORT_DOWNLOAD, MSG_EXPORT_MARKDOWN,
     MSG_GET_SELECTION, MSG_SELECTION_CHANGED,
+    STATUS_DOMAIN_EXPORT,
 } from './messages';
 
 // Max Markdown source size stored as pluginData (~50 KB — Figma's practical limit)
@@ -239,19 +240,21 @@ figma.showUI(__html__, { width: 400, height: 500 });
             const allFrames = figma.currentPage.findAllWithCriteria({ types: ['FRAME'] }) as FrameNode[];
             const frameMap = new Map(allFrames.map(n => [n.id, n]));
             exportResultCache.clear();
+            const nodes = frameIds.map(id => frameMap.get(id) ?? null);
+            const missing = frameIds.filter((_, i) => !nodes[i]);
+            for (const id of missing) {
+                figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${id}`, error: true, domain: STATUS_DOMAIN_EXPORT });
+            }
+            const validNodes = nodes.filter((n): n is FrameNode => n !== null);
+            const results = await Promise.allSettled(validNodes.map(node => exportFrame(node)));
             const frames: ExportFrameResult[] = [];
-            for (const frameId of frameIds) {
-                const node = frameMap.get(frameId) ?? null;
-                if (!node) {
-                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true, domain: 'export' });
-                    continue;
-                }
-                try {
-                    const result = await exportFrame(node);
-                    exportResultCache.set(frameId, result);
-                    frames.push(result);
-                } catch (e) {
-                    figma.ui.postMessage({ type: MSG_STATUS, message: `Failed to export frame "${node.name}": ${errorMessage(e)}`, error: true, domain: 'export' });
+            for (let i = 0; i < results.length; i++) {
+                const r = results[i];
+                if (r.status === 'fulfilled') {
+                    exportResultCache.set(validNodes[i].id, r.value);
+                    frames.push(r.value);
+                } else {
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Failed to export frame "${validNodes[i].name}": ${errorMessage(r.reason)}`, error: true, domain: STATUS_DOMAIN_EXPORT });
                 }
             }
             figma.ui.postMessage({ type: MSG_EXPORT_RESULT, frames });
@@ -266,7 +269,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
             if (!cached) {
                 const node = figma.currentPage.findOne((n: SceneNode) => n.id === frameId && n.type === 'FRAME') as FrameNode | null;
                 if (!node) {
-                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true, domain: 'export' });
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true, domain: STATUS_DOMAIN_EXPORT });
                     return;
                 }
                 const result = await exportFrame(node);

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -163,6 +163,14 @@ figma.showUI(__html__, { width: 400, height: 500 });
                     const result: RenderResult = await renderBlocks(nameNoExt, blocks, settings, target as SceneNode);
                     updatedCount++;
                     totalImageFailures += result.imageFailures;
+                    // Store source for round-trip export. Skip if > 50 KB to avoid pluginData limits.
+                    if (file.content.length <= 50_000) {
+                        result.frame.setPluginData('markdownSource', file.content);
+                        result.frame.setPluginData('markdownFilename', file.name);
+                        result.frame.setPluginData('markdownImportedAt', Date.now().toString());
+                    } else {
+                        result.frame.setPluginData('markdownSourceTruncated', 'true');
+                    }
                     // Record in import history (fire-and-forget — don't block render)
                     recordImport(file.name, blocks.length).catch(err => { console.error('[MarkDown For What] Failed to record import history:', err); });
                 } catch (e) {

--- a/figma-markdown-sync/code.ts
+++ b/figma-markdown-sync/code.ts
@@ -15,7 +15,7 @@ import {
     STATUS_DOMAIN_EXPORT,
 } from './messages';
 
-// Max Markdown source size stored as pluginData (~50 KB — Figma's practical limit)
+// Self-imposed cap on stored Markdown source (~50 KB). Keeps pluginData lean. Increase if needed.
 const MAX_MARKDOWN_SOURCE_SIZE = 50_000;
 
 // Initialize UI — 400×500 px panel, Figma Design only (not FigJam or Slides)
@@ -29,7 +29,9 @@ figma.showUI(__html__, { width: 400, height: 500 });
     }
 
     // Cache export results by frameId — reused by MSG_EXPORT_DOWNLOAD to avoid re-inferring.
-    // Cleared at the start of each MSG_EXPORT_REQUEST to prevent stale results after selection changes.
+    // Cleared at the start of each MSG_EXPORT_REQUEST to prevent stale results.
+    // Cache misses during MSG_EXPORT_DOWNLOAD fall through to a fresh exportFrame call;
+    // that result is not written back to the cache.
     const exportResultCache = new Map<string, ExportFrameResult>();
 
     // Notify UI whenever the Figma selection changes
@@ -162,6 +164,7 @@ figma.showUI(__html__, { width: 400, height: 500 });
                 });
             }
 
+            let truncatedCount = 0;
             let updatedCount = 0;
             let failedCount = 0;
             let totalImageFailures = 0;
@@ -193,9 +196,10 @@ figma.showUI(__html__, { width: 400, height: 500 });
                         result.frame.setPluginData('markdownFilename', file.name);
                         result.frame.setPluginData('markdownImportedAt', Date.now().toString());
                     } else {
-                        // If content exceeds MAX_MARKDOWN_SOURCE_SIZE, record that the source was too large
-                        // but do not store content. All blocks will be marked 'new' on export.
+                        // Source too large to store. The truncated flag causes exportFrame to run diffBlocks
+                        // against an empty source array, so all blocks appear as 'new' on export.
                         result.frame.setPluginData('markdownSourceTruncated', 'true');
+                        truncatedCount++;
                     }
                     // Record in import history (fire-and-forget — don't block render)
                     recordImport(file.name, blocks.length).catch(err => { console.error('[MarkDown For What] Failed to record import history:', err); });
@@ -216,6 +220,10 @@ figma.showUI(__html__, { width: 400, height: 500 });
 
             if (totalImageFailures > 0) {
                 statusMessage += ` (${totalImageFailures} image${totalImageFailures === 1 ? '' : 's'} failed to load)`;
+            }
+
+            if (truncatedCount > 0) {
+                statusMessage += ` Note: ${truncatedCount} file${truncatedCount === 1 ? '' : 's'} exceeded the ${MAX_MARKDOWN_SOURCE_SIZE / 1000} KB source storage limit — export will produce inferred-only output for those files.`;
             }
 
             figma.ui.postMessage({
@@ -272,9 +280,13 @@ figma.showUI(__html__, { width: 400, height: 500 });
                     figma.ui.postMessage({ type: MSG_STATUS, message: `Frame not found: ${frameId}`, error: true, domain: STATUS_DOMAIN_EXPORT });
                     return;
                 }
-                const result = await exportFrame(node);
-                const content = assembleMarkdown(result.blocks, selections);
-                figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: result.filename, content });
+                try {
+                    const result = await exportFrame(node);
+                    const content = assembleMarkdown(result.blocks, selections);
+                    figma.ui.postMessage({ type: MSG_EXPORT_MARKDOWN, filename: result.filename, content });
+                } catch (e) {
+                    figma.ui.postMessage({ type: MSG_STATUS, message: `Failed to export frame "${node.name}": ${errorMessage(e)}`, error: true, domain: STATUS_DOMAIN_EXPORT });
+                }
                 return;
             }
             const content = assembleMarkdown(cached.blocks, selections);

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -279,12 +279,12 @@ describe('assembleMarkdown', () => {
         const blocks: ExportBlock[] = [
             { state: 'modified', originalText: 'Old text', inferredText: 'New text' },
         ];
-        expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: false }])).toBe('New text');
+        expect(assembleMarkdown(blocks, [{ blockIndex: 0, action: 'use-inferred' }])).toBe('New text');
     });
 
-    it('respects BlockSelection useOriginal=true to skip a new block', () => {
+    it('respects BlockSelection action=skip to skip a new block', () => {
         const blocks: ExportBlock[] = [{ state: 'new', inferredText: 'Unwanted' }];
-        expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: true }])).toBe('');
+        expect(assembleMarkdown(blocks, [{ blockIndex: 0, action: 'skip' }])).toBe('');
     });
 
     it('separates blocks with a blank line', () => {
@@ -315,7 +315,7 @@ describe('assembleMarkdown', () => {
 describe('exportFrame', () => {
     beforeEach(() => jest.clearAllMocks());
 
-    it('returns hasStoredSource: true when markdownSource is present', async () => {
+    it('returns sourceStatus: present when markdownSource is present', async () => {
         const frame = makeMockFrame() as any;
         frame._pluginData['markdownSource'] = '# Hello\n\nWorld';
         frame._pluginData['markdownFilename'] = 'test.md';
@@ -324,25 +324,22 @@ describe('exportFrame', () => {
             getTextStyleIdAsync: jest.fn().mockResolvedValue('') };
         frame.children = [textNode];
         const result = await exportFrame(frame);
-        expect(result.hasStoredSource).toBe(true);
-        expect(result.sourceTruncated).toBe(false);
+        expect(result.sourceStatus).toBe('present');
     });
 
-    it('returns hasStoredSource: true and sourceTruncated: true when truncated flag is set', async () => {
+    it('returns sourceStatus: truncated when truncated flag is set', async () => {
         const frame = makeMockFrame() as any;
         frame._pluginData['markdownSourceTruncated'] = 'true';
         frame.children = [];
         const result = await exportFrame(frame);
-        expect(result.hasStoredSource).toBe(true);
-        expect(result.sourceTruncated).toBe(true);
+        expect(result.sourceStatus).toBe('truncated');
     });
 
-    it('returns hasStoredSource: false for frames with no pluginData', async () => {
+    it('returns sourceStatus: none for frames with no pluginData', async () => {
         const frame = makeMockFrame() as any;
         frame.children = [];
         const result = await exportFrame(frame);
-        expect(result.hasStoredSource).toBe(false);
-        expect(result.sourceTruncated).toBe(false);
+        expect(result.sourceStatus).toBe('none');
     });
 
     it('uses markdownFilename for filename, then frame.name, then "export"', async () => {
@@ -373,5 +370,194 @@ describe('exportFrame', () => {
         frame.children = [textNode];
         const result = await exportFrame(frame);
         expect(result.blocks.every((b: any) => b.state === 'new')).toBe(true);
+    });
+});
+
+// ── inferBlocksFromFrame — figma.mixed and per-node error handling ─────────────
+
+describe('inferBlocksFromFrame — mixed styles and error handling', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('skips text nodes with mixed styles and records them in skippedLayers', async () => {
+        const frame = {
+            children: [{
+                type: 'TEXT',
+                name: 'Mixed',
+                characters: 'mixed text',
+                getTextStyleIdAsync: jest.fn().mockResolvedValue((figma as any).mixed),
+            }],
+        };
+        const { blocks, skippedLayers } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(0);
+        expect(skippedLayers).toHaveLength(1);
+        expect(skippedLayers[0].reason).toContain('Mixed text styles');
+    });
+
+    it('catches per-node inference errors and records them in skippedLayers without aborting the frame', async () => {
+        const frame = {
+            children: [
+                {
+                    type: 'TEXT',
+                    name: 'Broken',
+                    getTextStyleIdAsync: jest.fn().mockRejectedValue(new Error('API timeout')),
+                },
+                {
+                    type: 'RECTANGLE',
+                    name: 'separator',
+                    height: 1,
+                    fills: [],
+                },
+            ],
+        };
+        const { blocks, skippedLayers } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].blockType).toBe('separator');
+        expect(skippedLayers).toHaveLength(1);
+        expect(skippedLayers[0].name).toBe('Broken');
+        expect(skippedLayers[0].reason).toContain('API timeout');
+    });
+});
+
+// ── guessBlockType — via diffBlocks fingerprinting ────────────────────────────
+
+describe('guessBlockType — via diffBlocks fingerprinting', () => {
+    it('classifies ordered list items as list type (matches inferred list block)', () => {
+        const source = ['1. First item'];
+        const inferred: InferredBlock[] = [{ blockType: 'list', text: '1. First item', label: 'List' }];
+        const result = diffBlocks(source, inferred);
+        expect(result[0].state).toBe('unchanged');
+    });
+
+    it('classifies h4-h6 as heading-other (never matches inferred blocks — always new)', () => {
+        const source = ['#### Deep Heading'];
+        const inferred: InferredBlock[] = [{ blockType: 'paragraph', text: '#### Deep Heading', label: 'Para' }];
+        const result = diffBlocks(source, inferred);
+        // heading-other vs paragraph — type mismatch means no content-hash match and position fallback also fails (different type)
+        expect(result[0].state).toBe('new');
+    });
+});
+
+// ── inferTableFrame ───────────────────────────────────────────────────────────
+
+describe('inferBlocksFromFrame — named frames (table, definition list, footnotes, badge row)', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('inferTableFrame: empty table returns fidelity warning', async () => {
+        const tableFrame = makeFrame('Table', []);
+        const root = makeFrame('Root', [tableFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].fidelityWarning).toContain('Empty table');
+        expect(blocks[0].text).toBe('');
+    });
+
+    it('inferTableFrame: single-row table uses first row as header with separator', async () => {
+        const tableFrame = makeFrame('Table', [
+            { type: 'FRAME', children: [
+                { type: 'FRAME', children: [{ type: 'TEXT', characters: 'Col A' }] },
+                { type: 'FRAME', children: [{ type: 'TEXT', characters: 'Col B' }] },
+            ]},
+        ]);
+        const root = makeFrame('Root', [tableFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toContain('| Col A | Col B |');
+        expect(blocks[0].text).toContain('| --- | --- |');
+    });
+
+    it('inferTableFrame: multi-row table includes body rows', async () => {
+        const tableFrame = makeFrame('Table', [
+            { type: 'FRAME', children: [
+                { type: 'FRAME', children: [{ type: 'TEXT', characters: 'H1' }] },
+                { type: 'FRAME', children: [{ type: 'TEXT', characters: 'H2' }] },
+            ]},
+            { type: 'FRAME', children: [
+                { type: 'FRAME', children: [{ type: 'TEXT', characters: 'R1C1' }] },
+                { type: 'FRAME', children: [{ type: 'TEXT', characters: 'R1C2' }] },
+            ]},
+        ]);
+        const root = makeFrame('Root', [tableFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toContain('| H1 | H2 |');
+        expect(blocks[0].text).toContain('| --- | --- |');
+        expect(blocks[0].text).toContain('| R1C1 | R1C2 |');
+    });
+
+    // ── inferDefinitionListFrame ──────────────────────────────────────────────
+
+    it('inferDefinitionListFrame: even number of text nodes produces paired term/definition', async () => {
+        const defFrame = makeFrame('Definition List', [
+            { type: 'TEXT', characters: 'Term 1' },
+            { type: 'TEXT', characters: 'Definition 1' },
+            { type: 'TEXT', characters: 'Term 2' },
+            { type: 'TEXT', characters: 'Definition 2' },
+        ]);
+        const root = makeFrame('Root', [defFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('Term 1\n: Definition 1\nTerm 2\n: Definition 2');
+    });
+
+    it('inferDefinitionListFrame: odd number of text nodes handles gracefully', async () => {
+        const defFrame = makeFrame('Definition List', [
+            { type: 'TEXT', characters: 'Term 1' },
+            { type: 'TEXT', characters: 'Definition 1' },
+            { type: 'TEXT', characters: 'Orphan term' },
+        ]);
+        const root = makeFrame('Root', [defFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toContain('Term 1');
+        expect(blocks[0].text).toContain('Orphan term');
+    });
+
+    // ── inferFootnotesFrame ───────────────────────────────────────────────────
+
+    it('inferFootnotesFrame: produces numbered footnote references', async () => {
+        const footnotesFrame = makeFrame('Footnotes', [
+            { type: 'TEXT', characters: 'First note' },
+            { type: 'TEXT', characters: 'Second note' },
+        ]);
+        const root = makeFrame('Root', [footnotesFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('[^1]: First note\n[^2]: Second note');
+        expect(blocks[0].blockType).toBe('footnoteSection');
+    });
+
+    // ── inferBadgeRowFrame ────────────────────────────────────────────────────
+
+    it('inferBadgeRowFrame: extracts badge children and ignores non-badge children', async () => {
+        const badgeFrame = makeFrame('Badge Row', [
+            { name: 'Badge: Alpha', type: 'FRAME' },
+            { name: 'Not a badge', type: 'FRAME' },
+            { name: 'Badge: Beta', type: 'FRAME' },
+        ]);
+        const root = makeFrame('Root', [badgeFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('[badge:Alpha] [badge:Beta]');
+        expect(blocks[0].blockType).toBe('badgeRow');
+    });
+
+    it('inferBadgeRowFrame: empty badge row returns empty text', async () => {
+        const badgeFrame = makeFrame('Badge Row', [
+            { name: 'Not a badge', type: 'FRAME' },
+        ]);
+        const root = makeFrame('Root', [badgeFrame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('');
+    });
+});
+
+// ── diffBlocks — fidelityWarning propagation ──────────────────────────────────
+
+describe('diffBlocks — fidelityWarning propagation', () => {
+    it('propagates fidelityWarning from InferredBlock onto modified ExportBlock', () => {
+        const source = ['# Old Title'];
+        const inferred: InferredBlock[] = [{
+            blockType: 'heading-1',
+            text: '# New Title',
+            label: 'H1',
+            fidelityWarning: 'Link lost in export',
+        }];
+        const result = diffBlocks(source, inferred);
+        expect(result[0].state).toBe('modified');
+        const block = result[0] as Extract<typeof result[0], { state: 'modified' }>;
+        expect(block.fidelityWarning).toBe('Link lost in export');
     });
 });

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -9,7 +9,7 @@ import {
     assembleMarkdown,
     exportFrame,
 } from './exporter';
-import type { InferredBlock, ExportBlock, BlockSelection } from './exporter';
+import type { BlockType, InferredBlock, ExportBlock, BlockSelection } from './exporter';
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -79,7 +79,7 @@ describe('normalizeContent', () => {
 
 describe('fingerprintBlock', () => {
     it('produces type:normalizedContent string', () => {
-        expect(fingerprintBlock('heading', '  Hello World  ')).toBe('heading:Hello World');
+        expect(fingerprintBlock('heading-1', '  Hello World  ')).toBe('heading-1:Hello World');
     });
 
     it('is case-sensitive', () => {
@@ -197,26 +197,26 @@ describe('inferBlocksFromFrame — named frames', () => {
 // ── diffBlocks ────────────────────────────────────────────────────────────────
 
 describe('diffBlocks', () => {
-    const makeInferred = (blockType: string, text: string, label = blockType): InferredBlock =>
+    const makeInferred = (blockType: BlockType, text: string, label: string = blockType): InferredBlock =>
         ({ text, blockType, label });
 
     it('marks blocks as unchanged when fingerprints match', () => {
         const result = diffBlocks(['# Hello World'], [makeInferred('heading-1', '# Hello World', 'Heading 1')]);
         expect(result[0].state).toBe('unchanged');
-        expect(result[0].originalText).toBe('# Hello World');
+        expect((result[0] as Extract<typeof result[0], { state: 'unchanged' }>).originalText).toBe('# Hello World');
     });
 
     it('marks blocks as modified when same position, different content', () => {
         const result = diffBlocks(['# Old Title'], [makeInferred('heading-1', '# New Title', 'Heading 1')]);
         expect(result[0].state).toBe('modified');
-        expect(result[0].originalText).toBe('# Old Title');
+        expect((result[0] as Extract<typeof result[0], { state: 'modified' }>).originalText).toBe('# Old Title');
         expect(result[0].inferredText).toBe('# New Title');
     });
 
     it('marks blocks as new when no source block exists', () => {
         const result = diffBlocks([], [makeInferred('paragraph', 'New paragraph', 'Paragraph')]);
         expect(result[0].state).toBe('new');
-        expect(result[0].originalText).toBeUndefined();
+        expect('originalText' in result[0]).toBe(false);
     });
 
     it('uses content-hash matching across positions (insertion tolerance)', () => {
@@ -239,8 +239,8 @@ describe('diffBlocks', () => {
     it('handles duplicate fingerprints correctly — each maps to a distinct source line', () => {
         const source = ['- Item', '- Item', '# Title'];
         const inferred: InferredBlock[] = [
-            { blockType: 'listItem', text: '- Item', label: 'List item' },
-            { blockType: 'listItem', text: '- Item', label: 'List item' },
+            { blockType: 'list', text: '- Item', label: 'List item' },
+            { blockType: 'list', text: '- Item', label: 'List item' },
             { blockType: 'heading-1', text: '# Title', label: 'H1' },
         ];
         const result = diffBlocks(source, inferred);
@@ -248,8 +248,8 @@ describe('diffBlocks', () => {
         expect(result[1].state).toBe('unchanged');
         expect(result[2].state).toBe('unchanged');
         // Both duplicate list items should reference distinct original texts
-        expect(result[0].originalText).toBe('- Item');
-        expect(result[1].originalText).toBe('- Item');
+        expect((result[0] as Extract<typeof result[0], { state: 'unchanged' }>).originalText).toBe('- Item');
+        expect((result[1] as Extract<typeof result[0], { state: 'unchanged' }>).originalText).toBe('- Item');
     });
 });
 

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -235,6 +235,22 @@ describe('diffBlocks', () => {
     it('returns empty array when both inputs are empty', () => {
         expect(diffBlocks([], [])).toEqual([]);
     });
+
+    it('handles duplicate fingerprints correctly — each maps to a distinct source line', () => {
+        const source = ['- Item', '- Item', '# Title'];
+        const inferred: InferredBlock[] = [
+            { blockType: 'listItem', text: '- Item', label: 'List item' },
+            { blockType: 'listItem', text: '- Item', label: 'List item' },
+            { blockType: 'heading-1', text: '# Title', label: 'H1' },
+        ];
+        const result = diffBlocks(source, inferred);
+        expect(result[0].state).toBe('unchanged');
+        expect(result[1].state).toBe('unchanged');
+        expect(result[2].state).toBe('unchanged');
+        // Both duplicate list items should reference distinct original texts
+        expect(result[0].originalText).toBe('- Item');
+        expect(result[1].originalText).toBe('- Item');
+    });
 });
 
 // ── assembleMarkdown ──────────────────────────────────────────────────────────
@@ -277,6 +293,20 @@ describe('assembleMarkdown', () => {
             { state: 'new', inferredText: 'Body text' },
         ];
         expect(assembleMarkdown(blocks, [])).toBe('# Title\n\nBody text');
+    });
+
+    it('silently drops blocks with empty or whitespace-only text', () => {
+        const blocks: ExportBlock[] = [
+            { state: 'new', inferredText: '# Title' },
+            { state: 'new', inferredText: '' },
+            { state: 'new', inferredText: '   ' },
+            { state: 'new', inferredText: 'Content' },
+        ];
+        const result = assembleMarkdown(blocks);
+        const lines = result.split('\n\n');
+        expect(lines.filter(l => l.trim().length > 0)).toHaveLength(2);
+        expect(result).toContain('# Title');
+        expect(result).toContain('Content');
     });
 });
 

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -180,3 +180,46 @@ describe('inferBlocksFromFrame — named frames', () => {
         expect(blocks[0].fidelityWarning).toMatch(/url not recoverable/i);
     });
 });
+
+// ── diffBlocks ────────────────────────────────────────────────────────────────
+
+describe('diffBlocks', () => {
+    const makeInferred = (blockType: string, text: string, label = blockType): InferredBlock =>
+        ({ text, blockType, label });
+
+    it('marks blocks as unchanged when fingerprints match', () => {
+        const result = diffBlocks(['# Hello World'], [makeInferred('heading-1', '# Hello World', 'Heading 1')]);
+        expect(result[0].state).toBe('unchanged');
+        expect(result[0].originalText).toBe('# Hello World');
+    });
+
+    it('marks blocks as modified when same position, different content', () => {
+        const result = diffBlocks(['# Old Title'], [makeInferred('heading-1', '# New Title', 'Heading 1')]);
+        expect(result[0].state).toBe('modified');
+        expect(result[0].originalText).toBe('# Old Title');
+        expect(result[0].inferredText).toBe('# New Title');
+    });
+
+    it('marks blocks as new when no source block exists', () => {
+        const result = diffBlocks([], [makeInferred('paragraph', 'New paragraph', 'Paragraph')]);
+        expect(result[0].state).toBe('new');
+        expect(result[0].originalText).toBeUndefined();
+    });
+
+    it('uses content-hash matching across positions (insertion tolerance)', () => {
+        const source = ['First paragraph', 'Second paragraph'];
+        const inferred = [
+            makeInferred('paragraph', 'Brand new intro', 'Paragraph'),
+            makeInferred('paragraph', 'First paragraph', 'Paragraph'),
+            makeInferred('paragraph', 'Second paragraph', 'Paragraph'),
+        ];
+        const result = diffBlocks(source, inferred);
+        expect(result.find(b => b.inferredText === 'Brand new intro')?.state).toBe('new');
+        expect(result.find(b => b.inferredText === 'First paragraph')?.state).toBe('unchanged');
+        expect(result.find(b => b.inferredText === 'Second paragraph')?.state).toBe('unchanged');
+    });
+
+    it('returns empty array when both inputs are empty', () => {
+        expect(diffBlocks([], [])).toEqual([]);
+    });
+});

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for exporter.ts — inference, diff engine, and Markdown assembly.
+ */
+import {
+    inferBlocksFromFrame,
+    normalizeContent,
+    fingerprintBlock,
+    diffBlocks,
+    assembleMarkdown,
+} from './exporter';
+import type { InferredBlock, DiffBlock, BlockSelection } from './exporter';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTextNode(overrides: Partial<any> = {}): any {
+    return {
+        type: 'TEXT',
+        name: '',
+        characters: 'Hello world',
+        _pluginData: {} as Record<string, string>,
+        getPluginData: jest.fn(function(this: any, k: string) { return this._pluginData[k] ?? ''; }),
+        getTextStyleIdAsync: jest.fn().mockResolvedValue(''),
+        ...overrides,
+    };
+}
+
+function makeRectNode(overrides: Partial<any> = {}): any {
+    return {
+        type: 'RECTANGLE',
+        name: '',
+        width: 800,
+        height: 1,
+        fills: [{ type: 'SOLID' }],
+        ...overrides,
+    };
+}
+
+function makeFrame(name: string, children: any[] = [], overrides: Partial<any> = {}): any {
+    return {
+        type: 'FRAME',
+        name,
+        children,
+        _pluginData: {} as Record<string, string>,
+        getPluginData: jest.fn(function(this: any, k: string) { return this._pluginData[k] ?? ''; }),
+        ...overrides,
+    };
+}
+
+// ── normalizeContent ─────────────────────────────────────────────────────────
+
+describe('normalizeContent', () => {
+    it('strips leading and trailing whitespace', () => {
+        expect(normalizeContent('  hello  ')).toBe('hello');
+    });
+
+    it('collapses internal whitespace runs to a single space', () => {
+        expect(normalizeContent('foo   bar\tbaz')).toBe('foo bar baz');
+    });
+
+    it('returns empty string for blank input', () => {
+        expect(normalizeContent('   ')).toBe('');
+    });
+});
+
+// ── fingerprintBlock ─────────────────────────────────────────────────────────
+
+describe('fingerprintBlock', () => {
+    it('produces type:normalizedContent string', () => {
+        expect(fingerprintBlock('heading', '  Hello World  ')).toBe('heading:Hello World');
+    });
+
+    it('is case-sensitive', () => {
+        expect(fingerprintBlock('paragraph', 'Foo')).not.toBe(fingerprintBlock('paragraph', 'foo'));
+    });
+});
+
+// ── inferBlocksFromFrame — text and separator nodes ───────────────────────────
+
+describe('inferBlocksFromFrame — text nodes', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('infers H1 from a text node with Markdown/H1 style name', async () => {
+        const text = makeTextNode({ characters: 'My Title' });
+        (figma.getStyleByIdAsync as jest.Mock).mockResolvedValue({ name: 'Markdown/H1' });
+        text.getTextStyleIdAsync.mockResolvedValue('style-id-h1');
+        const frame = makeFrame('Test', [text]);
+
+        const { blocks } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].text).toBe('# My Title');
+        expect(blocks[0].blockType).toBe('heading-1');
+    });
+
+    it('infers paragraph from Markdown/Body style', async () => {
+        const text = makeTextNode({ characters: 'Some body text' });
+        (figma.getStyleByIdAsync as jest.Mock).mockResolvedValue({ name: 'Markdown/Body' });
+        text.getTextStyleIdAsync.mockResolvedValue('style-id-body');
+        const frame = makeFrame('Test', [text]);
+
+        const { blocks } = await inferBlocksFromFrame(frame);
+        expect(blocks[0].text).toBe('Some body text');
+        expect(blocks[0].blockType).toBe('paragraph');
+    });
+
+    it('infers separator from a 1px-tall RECTANGLE node', async () => {
+        const rect = makeRectNode({ height: 1 });
+        const frame = makeFrame('Test', [rect]);
+
+        const { blocks } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].text).toBe('---');
+        expect(blocks[0].blockType).toBe('separator');
+    });
+
+    it('skips unknown nodes and records them in skippedLayers', async () => {
+        const unknown = { type: 'ELLIPSE', name: 'Shape', children: [] };
+        const frame = makeFrame('Test', [unknown]);
+
+        const { blocks, skippedLayers } = await inferBlocksFromFrame(frame);
+        expect(blocks).toHaveLength(0);
+        expect(skippedLayers[0].name).toBe('Shape');
+    });
+});
+
+// ── inferBlocksFromFrame — named frames ──────────────────────────────────────
+
+describe('inferBlocksFromFrame — named frames', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('infers Mermaid Diagram frame using pluginData source', async () => {
+        const frame = makeFrame('Mermaid Diagram');
+        frame._pluginData['mermaidSource'] = 'graph TD\nA-->B';
+        const root = makeFrame('Root', [frame]);
+
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('```mermaid\ngraph TD\nA-->B\n```');
+        expect(blocks[0].blockType).toBe('mermaid');
+        expect(blocks[0].fidelityWarning).toBeUndefined();
+    });
+
+    it('attaches a fidelity warning for Mermaid frames with no pluginData source', async () => {
+        const frame = makeFrame('Mermaid Diagram');
+        const root = makeFrame('Root', [frame]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].fidelityWarning).toMatch(/not recoverable/i);
+    });
+
+    it('infers callout block from "Callout: Warning" frame name', async () => {
+        const body = makeTextNode({ characters: 'Watch out!' });
+        (figma.getStyleByIdAsync as jest.Mock).mockResolvedValue({ name: 'Markdown/Body' });
+        body.getTextStyleIdAsync.mockResolvedValue('style-id');
+        const calloutFrame = makeFrame('Callout: Warning', [body]);
+        const root = makeFrame('Root', [calloutFrame]);
+
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toContain('[!WARNING]');
+        expect(blocks[0].blockType).toBe('callout');
+    });
+
+    it('infers list items from List Group frame', async () => {
+        const item1 = makeTextNode({ characters: 'First item' });
+        const item2 = makeTextNode({ characters: 'Second item' });
+        const group = makeFrame('List Group', [item1, item2]);
+        const root = makeFrame('Root', [group]);
+
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('- First item\n- Second item');
+        expect(blocks[0].blockType).toBe('listGroup');
+    });
+
+    it('infers image node from RECTANGLE with IMAGE fill', async () => {
+        const rect = makeRectNode({
+            height: 200,
+            name: 'My Screenshot',
+            fills: [{ type: 'IMAGE' }],
+        });
+        const root = makeFrame('Root', [rect]);
+        const { blocks } = await inferBlocksFromFrame(root);
+        expect(blocks[0].text).toBe('![My Screenshot](image-not-recoverable)');
+        expect(blocks[0].fidelityWarning).toMatch(/url not recoverable/i);
+    });
+});

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -7,8 +7,9 @@ import {
     fingerprintBlock,
     diffBlocks,
     assembleMarkdown,
+    exportFrame,
 } from './exporter';
-import type { InferredBlock, DiffBlock, BlockSelection } from './exporter';
+import type { InferredBlock, ExportBlock, BlockSelection } from './exporter';
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -40,6 +41,18 @@ function makeFrame(name: string, children: any[] = [], overrides: Partial<any> =
         type: 'FRAME',
         name,
         children,
+        _pluginData: {} as Record<string, string>,
+        getPluginData: jest.fn(function(this: any, k: string) { return this._pluginData[k] ?? ''; }),
+        ...overrides,
+    };
+}
+
+function makeMockFrame(overrides: Partial<any> = {}): any {
+    return {
+        type: 'FRAME',
+        id: 'frame-1',
+        name: 'My Frame',
+        children: [],
         _pluginData: {} as Record<string, string>,
         getPluginData: jest.fn(function(this: any, k: string) { return this._pluginData[k] ?? ''; }),
         ...overrides,
@@ -228,41 +241,107 @@ describe('diffBlocks', () => {
 
 describe('assembleMarkdown', () => {
     it('uses originalText for unchanged blocks (preserves inline formatting)', () => {
-        const blocks: DiffBlock[] = [
-            { state: 'unchanged', originalText: '# My [linked](url) Heading', inferredText: '# My linked Heading', label: 'Heading 1' },
+        const blocks: ExportBlock[] = [
+            { state: 'unchanged', originalText: '# My [linked](url) Heading', inferredText: '# My linked Heading' },
         ];
         expect(assembleMarkdown(blocks, [])).toBe('# My [linked](url) Heading');
     });
 
     it('uses inferredText for new blocks', () => {
-        const blocks: DiffBlock[] = [{ state: 'new', inferredText: 'New paragraph', label: 'Paragraph' }];
+        const blocks: ExportBlock[] = [{ state: 'new', inferredText: 'New paragraph' }];
         expect(assembleMarkdown(blocks, [])).toBe('New paragraph');
     });
 
     it('uses originalText by default for modified blocks (conservative)', () => {
-        const blocks: DiffBlock[] = [
-            { state: 'modified', originalText: 'Old text', inferredText: 'New text', label: 'Paragraph' },
+        const blocks: ExportBlock[] = [
+            { state: 'modified', originalText: 'Old text', inferredText: 'New text' },
         ];
         expect(assembleMarkdown(blocks, [])).toBe('Old text');
     });
 
     it('respects BlockSelection to use inferred for modified block', () => {
-        const blocks: DiffBlock[] = [
-            { state: 'modified', originalText: 'Old text', inferredText: 'New text', label: 'Paragraph' },
+        const blocks: ExportBlock[] = [
+            { state: 'modified', originalText: 'Old text', inferredText: 'New text' },
         ];
         expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: false }])).toBe('New text');
     });
 
     it('respects BlockSelection useOriginal=true to skip a new block', () => {
-        const blocks: DiffBlock[] = [{ state: 'new', inferredText: 'Unwanted', label: 'Paragraph' }];
+        const blocks: ExportBlock[] = [{ state: 'new', inferredText: 'Unwanted' }];
         expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: true }])).toBe('');
     });
 
     it('separates blocks with a blank line', () => {
-        const blocks: DiffBlock[] = [
-            { state: 'unchanged', originalText: '# Title', inferredText: '# Title', label: 'Heading 1' },
-            { state: 'new', inferredText: 'Body text', label: 'Paragraph' },
+        const blocks: ExportBlock[] = [
+            { state: 'unchanged', originalText: '# Title', inferredText: '# Title' },
+            { state: 'new', inferredText: 'Body text' },
         ];
         expect(assembleMarkdown(blocks, [])).toBe('# Title\n\nBody text');
+    });
+});
+
+// ── exportFrame ───────────────────────────────────────────────────────────────
+
+describe('exportFrame', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('returns hasStoredSource: true when markdownSource is present', async () => {
+        const frame = makeMockFrame() as any;
+        frame._pluginData['markdownSource'] = '# Hello\n\nWorld';
+        frame._pluginData['markdownFilename'] = 'test.md';
+        // Add a child text node
+        const textNode = { type: 'TEXT', name: 'Body', characters: 'World', textStyleId: '',
+            getTextStyleIdAsync: jest.fn().mockResolvedValue('') };
+        frame.children = [textNode];
+        const result = await exportFrame(frame);
+        expect(result.hasStoredSource).toBe(true);
+        expect(result.sourceTruncated).toBe(false);
+    });
+
+    it('returns hasStoredSource: true and sourceTruncated: true when truncated flag is set', async () => {
+        const frame = makeMockFrame() as any;
+        frame._pluginData['markdownSourceTruncated'] = 'true';
+        frame.children = [];
+        const result = await exportFrame(frame);
+        expect(result.hasStoredSource).toBe(true);
+        expect(result.sourceTruncated).toBe(true);
+    });
+
+    it('returns hasStoredSource: false for frames with no pluginData', async () => {
+        const frame = makeMockFrame() as any;
+        frame.children = [];
+        const result = await exportFrame(frame);
+        expect(result.hasStoredSource).toBe(false);
+        expect(result.sourceTruncated).toBe(false);
+    });
+
+    it('uses markdownFilename for filename, then frame.name, then "export"', async () => {
+        const frame1 = makeMockFrame() as any;
+        frame1._pluginData['markdownSource'] = '# A';
+        frame1._pluginData['markdownFilename'] = 'my-spec.md';
+        frame1.children = [];
+        const r1 = await exportFrame(frame1);
+        expect(r1.filename).toBe('my-spec.md');
+
+        const frame2 = makeMockFrame() as any;
+        frame2.name = 'My Frame';
+        frame2.children = [];
+        const r2 = await exportFrame(frame2);
+        expect(r2.filename).toBe('My Frame.md');
+
+        const frame3 = makeMockFrame() as any;
+        frame3.name = '';
+        frame3.children = [];
+        const r3 = await exportFrame(frame3);
+        expect(r3.filename).toBe('export.md');
+    });
+
+    it('marks all blocks as new when no stored source', async () => {
+        const frame = makeMockFrame() as any;
+        const textNode = { type: 'TEXT', name: 'Body', characters: 'Hello', textStyleId: '',
+            getTextStyleIdAsync: jest.fn().mockResolvedValue('') };
+        frame.children = [textNode];
+        const result = await exportFrame(frame);
+        expect(result.blocks.every((b: any) => b.state === 'new')).toBe(true);
     });
 });

--- a/figma-markdown-sync/exporter.test.ts
+++ b/figma-markdown-sync/exporter.test.ts
@@ -223,3 +223,46 @@ describe('diffBlocks', () => {
         expect(diffBlocks([], [])).toEqual([]);
     });
 });
+
+// ── assembleMarkdown ──────────────────────────────────────────────────────────
+
+describe('assembleMarkdown', () => {
+    it('uses originalText for unchanged blocks (preserves inline formatting)', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'unchanged', originalText: '# My [linked](url) Heading', inferredText: '# My linked Heading', label: 'Heading 1' },
+        ];
+        expect(assembleMarkdown(blocks, [])).toBe('# My [linked](url) Heading');
+    });
+
+    it('uses inferredText for new blocks', () => {
+        const blocks: DiffBlock[] = [{ state: 'new', inferredText: 'New paragraph', label: 'Paragraph' }];
+        expect(assembleMarkdown(blocks, [])).toBe('New paragraph');
+    });
+
+    it('uses originalText by default for modified blocks (conservative)', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'modified', originalText: 'Old text', inferredText: 'New text', label: 'Paragraph' },
+        ];
+        expect(assembleMarkdown(blocks, [])).toBe('Old text');
+    });
+
+    it('respects BlockSelection to use inferred for modified block', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'modified', originalText: 'Old text', inferredText: 'New text', label: 'Paragraph' },
+        ];
+        expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: false }])).toBe('New text');
+    });
+
+    it('respects BlockSelection useOriginal=true to skip a new block', () => {
+        const blocks: DiffBlock[] = [{ state: 'new', inferredText: 'Unwanted', label: 'Paragraph' }];
+        expect(assembleMarkdown(blocks, [{ blockIndex: 0, useOriginal: true }])).toBe('');
+    });
+
+    it('separates blocks with a blank line', () => {
+        const blocks: DiffBlock[] = [
+            { state: 'unchanged', originalText: '# Title', inferredText: '# Title', label: 'Heading 1' },
+            { state: 'new', inferredText: 'Body text', label: 'Paragraph' },
+        ];
+        expect(assembleMarkdown(blocks, [])).toBe('# Title\n\nBody text');
+    });
+});

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -16,7 +16,7 @@
 export type BlockType =
     | 'heading-1' | 'heading-2' | 'heading-3' | 'heading-other'
     | 'paragraph' | 'code' | 'quote'
-    | 'list' | 'listGroup' | 'listItem'
+    | 'list' | 'listGroup'
     | 'separator' | 'image' | 'table' | 'toc' | 'callout'
     | 'definitionList' | 'footnoteSection' | 'badgeRow' | 'mermaid' | 'math';
 
@@ -32,18 +32,21 @@ export type ExportBlock =
     | { state: 'modified';  originalText: string;  inferredText: string; fidelityWarning?: string }
     | { state: 'new';                              inferredText: string; fidelityWarning?: string };
 
+export type SkippedLayer = { name: string; reason: string };
+
+export type SourceStatus = 'none' | 'present' | 'truncated';
+
 export interface ExportFrameResult {
     frameId: string;
     filename: string;
-    hasStoredSource: boolean;
-    sourceTruncated: boolean;
+    sourceStatus: SourceStatus;
     blocks: ExportBlock[];
-    skippedLayers: Array<{ name: string; reason: string }>;
+    skippedLayers: SkippedLayer[];
 }
 
 export interface BlockSelection {
     blockIndex: number;
-    useOriginal: boolean;
+    action: 'use-original' | 'use-inferred' | 'skip';
 }
 
 // ─── Helpers (exported for testing) ──────────────────────────────────────────
@@ -85,20 +88,25 @@ const FRAME_NAME_TO_BLOCK: Record<string, BlockType> = {
 
 interface InferenceResult {
     blocks: InferredBlock[];
-    skippedLayers: Array<{ name: string; reason: string }>;
+    skippedLayers: SkippedLayer[];
 }
 
 export async function inferBlocksFromFrame(frame: any): Promise<InferenceResult> {
     const blocks: InferredBlock[] = [];
-    const skippedLayers: Array<{ name: string; reason: string }> = [];
+    const skippedLayers: SkippedLayer[] = [];
 
     for (const child of (frame.children ?? [])) {
         const skippedBefore = skippedLayers.length;
-        const inferred = await inferNode(child, skippedLayers);
+        let inferred: InferredBlock | null = null;
+        try {
+            inferred = await inferNode(child, skippedLayers);
+        } catch (err) {
+            skippedLayers.push({ name: child.name || '(unnamed)', reason: `Inference failed: ${(err as any)?.message ?? String(err)}` });
+            continue;
+        }
         if (inferred) {
             blocks.push(inferred);
         } else if (skippedLayers.length === skippedBefore) {
-            // inferNode returned null without adding to skippedLayers — add generic entry
             skippedLayers.push({ name: child.name || '(unnamed)', reason: 'Unrecognized layer type or name' });
         }
     }
@@ -106,7 +114,7 @@ export async function inferBlocksFromFrame(frame: any): Promise<InferenceResult>
     return { blocks, skippedLayers };
 }
 
-async function inferNode(node: any, skippedLayers?: Array<{ name: string; reason: string }>): Promise<InferredBlock | null> {
+async function inferNode(node: any, skippedLayers?: SkippedLayer[]): Promise<InferredBlock | null> {
     if (node.type === 'RECTANGLE' && node.height === 1) {
         return { text: '---', blockType: 'separator', label: 'Separator' };
     }
@@ -127,9 +135,10 @@ async function inferNode(node: any, skippedLayers?: Array<{ name: string; reason
     return null;
 }
 
-async function inferTextNode(node: any, skippedLayers?: Array<{ name: string; reason: string }>): Promise<InferredBlock | null> {
+async function inferTextNode(node: any, skippedLayers?: SkippedLayer[]): Promise<InferredBlock | null> {
     const styleId = await node.getTextStyleIdAsync();
     if (styleId === (figma as any).mixed) {
+        // figma.mixed is a runtime sentinel (not in TS typedefs) indicating the node has multiple different text styles applied.
         skippedLayers?.push({ name: node.name || '(unnamed)', reason: 'Mixed text styles not supported' });
         return null;
     }
@@ -278,8 +287,48 @@ function inferBadgeRowFrame(node: any): InferredBlock {
 // ─── Diff and Merge ───────────────────────────────────────────────────────────
 
 /**
- * Heuristic: infer block type from Markdown text prefix, for fingerprinting
- * source lines that were not produced by the inference engine.
+ * Splits stored Markdown source into block strings on blank lines,
+ * but does NOT split inside fenced blocks (``` or ~~~ or $$ math fences),
+ * which can contain intentional blank lines.
+ */
+function splitStoredSource(source: string): string[] {
+    const blocks: string[] = [];
+    let current = '';
+    let inFence = false;
+    let closingFence = '';
+
+    for (const line of source.split('\n')) {
+        const trimmed = line.trim();
+        if (!inFence) {
+            const fenceMatch = trimmed.match(/^(`{3,}|~{3,}|\$\$)/);
+            if (fenceMatch) {
+                inFence = true;
+                closingFence = fenceMatch[1] === '$$' ? '$$' : fenceMatch[1].charAt(0).repeat(fenceMatch[1].length);
+                current += (current ? '\n' : '') + line;
+            } else if (trimmed === '') {
+                if (current.trim()) {
+                    blocks.push(current.trim());
+                    current = '';
+                }
+            } else {
+                current += (current ? '\n' : '') + line;
+            }
+        } else {
+            current += '\n' + line;
+            if (trimmed.startsWith(closingFence) && !trimmed.slice(closingFence.length).trim()) {
+                inFence = false;
+                closingFence = '';
+            }
+        }
+    }
+    if (current.trim()) blocks.push(current.trim());
+    return blocks;
+}
+
+/**
+ * Heuristic: infer block type from Markdown text prefix.
+ * Used only for source lines from stored pluginData; inferred blocks carry their BlockType directly.
+ * Note: 'heading-other' (h4–h6) is produced here but never by inference — h4–h6 always diff as 'new'.
  */
 function guessBlockType(text: string): BlockType {
     if (text.startsWith('# '))   return 'heading-1';
@@ -305,7 +354,7 @@ function guessBlockType(text: string): BlockType {
  * running the position fallback, preventing the fallback from consuming an
  * index needed by a later hash match.
  *
- * @param sourceLines - Markdown strings from stored pluginData, split by double-newline.
+ * @param sourceLines - Markdown block strings from stored pluginData, split by splitStoredSource.
  * @param inferredBlocks - Output of inferBlocksFromFrame.
  */
 export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[]): ExportBlock[] {
@@ -399,18 +448,17 @@ export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[
 }
 
 /**
- * Merges DiffBlocks into a final Markdown string.
+ * Assembles an ExportBlock array into a final Markdown string.
  *
  * Defaults per state:
  *   unchanged → originalText (preserves inline links, footnotes, etc.)
- *   modified  → originalText (conservative; user can override in review mode)
- *   new       → inferredText (include by default)
+ *   modified  → originalText (conservative; user can override with action='use-inferred')
+ *   new       → inferredText (included by default; skip with action='skip')
  *
- * For 'new' blocks: useOriginal = true means "skip this block".
  * Blocks are joined with a single blank line between them.
  */
 export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelection[] = []): string {
-    const selMap = new Map(selections.map(s => [s.blockIndex, s.useOriginal]));
+    const selMap = new Map(selections.map(s => [s.blockIndex, s.action]));
     const lines: string[] = [];
 
     for (let i = 0; i < blocks.length; i++) {
@@ -421,10 +469,9 @@ export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelecti
         if (block.state === 'unchanged') {
             text = block.originalText;
         } else if (block.state === 'modified') {
-            const useOriginal = override !== undefined ? override : true;
-            text = useOriginal ? block.originalText : block.inferredText;
+            text = override === 'use-inferred' ? block.inferredText : block.originalText; // default: use-original
         } else {
-            if (override === true) continue;
+            if (override === 'skip') continue;
             text = block.inferredText;
         }
 
@@ -442,8 +489,8 @@ export async function exportFrame(frame: any): Promise<ExportFrameResult> {
     const frameId: string = frame.id;
     const storedSource: string = frame.getPluginData('markdownSource');
     const storedFilename: string = frame.getPluginData('markdownFilename');
-    const sourceTruncated: boolean = frame.getPluginData('markdownSourceTruncated') === 'true';
-    const hasStoredSource: boolean = storedSource.length > 0 || sourceTruncated;
+    const truncated: boolean = frame.getPluginData('markdownSourceTruncated') === 'true';
+    const sourceStatus: SourceStatus = truncated ? 'truncated' : storedSource.length > 0 ? 'present' : 'none';
 
     const rawFilename = storedFilename || frame.name || 'export';
     const filename = rawFilename.replace(/\.md$/i, '') + '.md';
@@ -452,11 +499,9 @@ export async function exportFrame(frame: any): Promise<ExportFrameResult> {
 
     let diffResult: ExportBlock[];
 
-    if (hasStoredSource) {
-        const sourceLines = storedSource
-            .split(/\n\n+/)
-            .map((s: string) => s.trim())
-            .filter((s: string) => s.length > 0);
+    if (sourceStatus !== 'none') {
+        // storedSource is empty when truncated — diffBlocks([], …) produces all-'new' blocks.
+        const sourceLines = splitStoredSource(storedSource);
         diffResult = diffBlocks(sourceLines, inferredBlocks);
     } else {
         diffResult = inferredBlocks.map(b => ({
@@ -466,5 +511,5 @@ export async function exportFrame(frame: any): Promise<ExportFrameResult> {
         }));
     }
 
-    return { frameId, filename, hasStoredSource, sourceTruncated, blocks: diffResult, skippedLayers };
+    return { frameId, filename, sourceStatus, blocks: diffResult, skippedLayers };
 }

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -259,12 +259,93 @@ function inferBadgeRowFrame(node: any): InferredBlock {
     return { text: badges.join(' '), blockType: 'badgeRow', label: 'Badge Row' };
 }
 
-// ─── Placeholder stubs (implemented in later tasks) ──────────────────────────
+// ─── Diff and Merge ───────────────────────────────────────────────────────────
 
-export function diffBlocks(_sourceLines: string[], _inferredBlocks: InferredBlock[]): DiffBlock[] {
-    throw new Error('diffBlocks not yet implemented');
+/**
+ * Heuristic: infer block type from Markdown text prefix, for fingerprinting
+ * source lines that were not produced by the inference engine.
+ */
+function guessBlockType(text: string): string {
+    if (text.startsWith('# '))   return 'heading-1';
+    if (text.startsWith('## '))  return 'heading-2';
+    if (text.startsWith('### ')) return 'heading-3';
+    if (text.startsWith('> [!')) return 'callout';
+    if (text.startsWith('> '))   return 'quote';
+    if (text.startsWith('- ') || text.startsWith('* ')) return 'list';
+    if (text.startsWith('---'))  return 'separator';
+    if (text.startsWith('```'))  return 'code';
+    if (text.startsWith('$$'))   return 'math';
+    if (text.startsWith('|'))    return 'table';
+    return 'paragraph';
 }
 
+/**
+ * Diffs source Markdown strings against inferred blocks using content-hash
+ * matching with position+type as fallback.
+ *
+ * @param sourceLines - Markdown strings from stored pluginData, split by double-newline.
+ * @param inferredBlocks - Output of inferBlocksFromFrame.
+ */
+export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[]): DiffBlock[] {
+    const sourceByFingerprint = new Map<string, string>();
+    for (const line of sourceLines) {
+        const fp = fingerprintBlock(guessBlockType(line), line);
+        sourceByFingerprint.set(fp, line);
+    }
+
+    // First pass: identify which source indices will be consumed by content-hash matches
+    const sourceIndicesUsedByContentHash = new Set<number>();
+    for (const inferred of inferredBlocks) {
+        const fp = fingerprintBlock(inferred.blockType, inferred.text);
+        if (sourceByFingerprint.has(fp)) {
+            const matched = sourceByFingerprint.get(fp)!;
+            for (let i = 0; i < sourceLines.length; i++) {
+                if (sourceLines[i] === matched) {
+                    sourceIndicesUsedByContentHash.add(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    const usedSourceIndices = new Set<number>();
+    const result: DiffBlock[] = [];
+
+    for (let i = 0; i < inferredBlocks.length; i++) {
+        const inferred = inferredBlocks[i];
+        const fp = fingerprintBlock(inferred.blockType, inferred.text);
+
+        if (sourceByFingerprint.has(fp)) {
+            const originalText = sourceByFingerprint.get(fp)!;
+            sourceByFingerprint.delete(fp);
+            result.push({ state: 'unchanged', originalText, inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+            continue;
+        }
+
+        const sourceLine = sourceLines[i];
+        if (sourceLine !== undefined && guessBlockType(sourceLine) === inferred.blockType && !usedSourceIndices.has(i) && !sourceIndicesUsedByContentHash.has(i)) {
+            usedSourceIndices.add(i);
+            result.push({ state: 'modified', originalText: sourceLine, inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+            continue;
+        }
+
+        result.push({ state: 'new', inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+    }
+
+    return result;
+}
+
+/**
+ * Merges DiffBlocks into a final Markdown string.
+ *
+ * Defaults per state:
+ *   unchanged → originalText (preserves inline links, footnotes, etc.)
+ *   modified  → originalText (conservative; user can override in review mode)
+ *   new       → inferredText (include by default)
+ *
+ * For 'new' blocks: useOriginal = true means "skip this block".
+ * Blocks are joined with a single blank line between them.
+ */
 export function assembleMarkdown(_blocks: DiffBlock[], _selections: BlockSelection[]): string {
     throw new Error('assembleMarkdown not yet implemented');
 }

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -346,6 +346,63 @@ export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[
  * For 'new' blocks: useOriginal = true means "skip this block".
  * Blocks are joined with a single blank line between them.
  */
-export function assembleMarkdown(_blocks: DiffBlock[], _selections: BlockSelection[]): string {
-    throw new Error('assembleMarkdown not yet implemented');
+export function assembleMarkdown(blocks: DiffBlock[], selections: BlockSelection[]): string {
+    const selMap = new Map(selections.map(s => [s.blockIndex, s.useOriginal]));
+    const lines: string[] = [];
+
+    for (let i = 0; i < blocks.length; i++) {
+        const block = blocks[i];
+        const override = selMap.get(i);
+        let text: string;
+
+        if (block.state === 'unchanged') {
+            text = block.originalText!;
+        } else if (block.state === 'modified') {
+            const useOriginal = override !== undefined ? override : true;
+            text = useOriginal ? block.originalText! : block.inferredText;
+        } else {
+            if (override === true) continue;
+            text = block.inferredText;
+        }
+
+        if (text.trim().length > 0) lines.push(text);
+    }
+
+    return lines.join('\n\n');
+}
+
+/**
+ * Runs the full 4-stage export pipeline for a single Figma FrameNode.
+ * Returns an ExportFrameResult ready to send to the UI via postMessage.
+ */
+export async function exportFrame(frame: any): Promise<ExportFrameResult> {
+    const frameId: string = frame.id;
+    const storedSource: string = frame.getPluginData('markdownSource');
+    const storedFilename: string = frame.getPluginData('markdownFilename');
+    const sourceTruncated: boolean = frame.getPluginData('markdownSourceTruncated') === 'true';
+    const hasStoredSource: boolean = storedSource.length > 0 && !sourceTruncated;
+
+    const rawFilename = storedFilename || frame.name || 'export';
+    const filename = rawFilename.replace(/\.md$/i, '') + '.md';
+
+    const { blocks: inferredBlocks, skippedLayers } = await inferBlocksFromFrame(frame);
+
+    let diffResult: DiffBlock[];
+
+    if (hasStoredSource) {
+        const sourceLines = storedSource
+            .split(/\n\n+/)
+            .map((s: string) => s.trim())
+            .filter((s: string) => s.length > 0);
+        diffResult = diffBlocks(sourceLines, inferredBlocks);
+    } else {
+        diffResult = inferredBlocks.map(b => ({
+            state: 'new' as const,
+            inferredText: b.text,
+            label: b.label,
+            fidelityWarning: b.fidelityWarning,
+        }));
+    }
+
+    return { frameId, filename, hasStoredSource, sourceTruncated, blocks: diffResult, skippedLayers };
 }

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -20,11 +20,10 @@ export interface InferredBlock {
     fidelityWarning?: string;
 }
 
-export interface DiffBlock {
+export interface ExportBlock {
     state: 'unchanged' | 'modified' | 'new';
     originalText?: string;
     inferredText: string;
-    label: string;
     fidelityWarning?: string;
 }
 
@@ -33,7 +32,7 @@ export interface ExportFrameResult {
     filename: string;
     hasStoredSource: boolean;
     sourceTruncated: boolean;
-    blocks: DiffBlock[];
+    blocks: ExportBlock[];
     skippedLayers: Array<{ name: string; reason: string }>;
 }
 
@@ -271,8 +270,9 @@ function guessBlockType(text: string): string {
     if (text.startsWith('### ')) return 'heading-3';
     if (text.startsWith('> [!')) return 'callout';
     if (text.startsWith('> '))   return 'quote';
-    if (text.startsWith('- ') || text.startsWith('* ')) return 'list';
+    if (text.startsWith('- ') || /^\d+\. /.test(text)) return 'listItem';
     if (text.startsWith('---'))  return 'separator';
+    if (text.startsWith('```mermaid')) return 'mermaid';
     if (text.startsWith('```'))  return 'code';
     if (text.startsWith('$$'))   return 'math';
     if (text.startsWith('|'))    return 'table';
@@ -286,50 +286,53 @@ function guessBlockType(text: string): string {
  * @param sourceLines - Markdown strings from stored pluginData, split by double-newline.
  * @param inferredBlocks - Output of inferBlocksFromFrame.
  */
-export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[]): DiffBlock[] {
-    const sourceByFingerprint = new Map<string, string>();
-    for (const line of sourceLines) {
+export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[]): ExportBlock[] {
+    const sourceByFingerprint = new Map<string, number[]>();
+    for (let idx = 0; idx < sourceLines.length; idx++) {
+        const line = sourceLines[idx];
         const fp = fingerprintBlock(guessBlockType(line), line);
-        sourceByFingerprint.set(fp, line);
+        const existing = sourceByFingerprint.get(fp);
+        if (existing) {
+            existing.push(idx);
+        } else {
+            sourceByFingerprint.set(fp, [idx]);
+        }
     }
 
     // First pass: identify which source indices will be consumed by content-hash matches
     const sourceIndicesUsedByContentHash = new Set<number>();
     for (const inferred of inferredBlocks) {
         const fp = fingerprintBlock(inferred.blockType, inferred.text);
-        if (sourceByFingerprint.has(fp)) {
-            const matched = sourceByFingerprint.get(fp)!;
-            for (let i = 0; i < sourceLines.length; i++) {
-                if (sourceLines[i] === matched) {
-                    sourceIndicesUsedByContentHash.add(i);
-                    break;
-                }
-            }
+        const indices = sourceByFingerprint.get(fp);
+        if (indices && indices.length > 0) {
+            sourceIndicesUsedByContentHash.add(indices[0]);
         }
     }
 
     const usedSourceIndices = new Set<number>();
-    const result: DiffBlock[] = [];
+    const result: ExportBlock[] = [];
 
     for (let i = 0; i < inferredBlocks.length; i++) {
         const inferred = inferredBlocks[i];
         const fp = fingerprintBlock(inferred.blockType, inferred.text);
 
-        if (sourceByFingerprint.has(fp)) {
-            const originalText = sourceByFingerprint.get(fp)!;
-            sourceByFingerprint.delete(fp);
-            result.push({ state: 'unchanged', originalText, inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+        const fpIndices = sourceByFingerprint.get(fp);
+        if (fpIndices && fpIndices.length > 0) {
+            const matchedIdx = fpIndices.shift()!;
+            if (fpIndices.length === 0) sourceByFingerprint.delete(fp);
+            const originalText = sourceLines[matchedIdx];
+            result.push({ state: 'unchanged', originalText, inferredText: inferred.text });
             continue;
         }
 
         const sourceLine = sourceLines[i];
         if (sourceLine !== undefined && guessBlockType(sourceLine) === inferred.blockType && !usedSourceIndices.has(i) && !sourceIndicesUsedByContentHash.has(i)) {
             usedSourceIndices.add(i);
-            result.push({ state: 'modified', originalText: sourceLine, inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+            result.push({ state: 'modified', originalText: sourceLine, inferredText: inferred.text, fidelityWarning: inferred.fidelityWarning });
             continue;
         }
 
-        result.push({ state: 'new', inferredText: inferred.text, label: inferred.label, fidelityWarning: inferred.fidelityWarning });
+        result.push({ state: 'new', inferredText: inferred.text, fidelityWarning: inferred.fidelityWarning });
     }
 
     return result;
@@ -346,7 +349,7 @@ export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[
  * For 'new' blocks: useOriginal = true means "skip this block".
  * Blocks are joined with a single blank line between them.
  */
-export function assembleMarkdown(blocks: DiffBlock[], selections: BlockSelection[]): string {
+export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelection[]): string {
     const selMap = new Map(selections.map(s => [s.blockIndex, s.useOriginal]));
     const lines: string[] = [];
 
@@ -380,14 +383,14 @@ export async function exportFrame(frame: any): Promise<ExportFrameResult> {
     const storedSource: string = frame.getPluginData('markdownSource');
     const storedFilename: string = frame.getPluginData('markdownFilename');
     const sourceTruncated: boolean = frame.getPluginData('markdownSourceTruncated') === 'true';
-    const hasStoredSource: boolean = storedSource.length > 0 && !sourceTruncated;
+    const hasStoredSource: boolean = storedSource.length > 0 || sourceTruncated;
 
     const rawFilename = storedFilename || frame.name || 'export';
     const filename = rawFilename.replace(/\.md$/i, '') + '.md';
 
     const { blocks: inferredBlocks, skippedLayers } = await inferBlocksFromFrame(frame);
 
-    let diffResult: DiffBlock[];
+    let diffResult: ExportBlock[];
 
     if (hasStoredSource) {
         const sourceLines = storedSource
@@ -399,7 +402,6 @@ export async function exportFrame(frame: any): Promise<ExportFrameResult> {
         diffResult = inferredBlocks.map(b => ({
             state: 'new' as const,
             inferredText: b.text,
-            label: b.label,
             fidelityWarning: b.fidelityWarning,
         }));
     }

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -88,10 +88,12 @@ export async function inferBlocksFromFrame(frame: any): Promise<InferenceResult>
     const skippedLayers: Array<{ name: string; reason: string }> = [];
 
     for (const child of (frame.children ?? [])) {
-        const inferred = await inferNode(child);
+        const skippedBefore = skippedLayers.length;
+        const inferred = await inferNode(child, skippedLayers);
         if (inferred) {
             blocks.push(inferred);
-        } else {
+        } else if (skippedLayers.length === skippedBefore) {
+            // inferNode returned null without adding to skippedLayers — add generic entry
             skippedLayers.push({ name: child.name || '(unnamed)', reason: 'Unrecognized layer type or name' });
         }
     }
@@ -99,7 +101,7 @@ export async function inferBlocksFromFrame(frame: any): Promise<InferenceResult>
     return { blocks, skippedLayers };
 }
 
-async function inferNode(node: any): Promise<InferredBlock | null> {
+async function inferNode(node: any, skippedLayers?: Array<{ name: string; reason: string }>): Promise<InferredBlock | null> {
     if (node.type === 'RECTANGLE' && node.height === 1) {
         return { text: '---', blockType: 'separator', label: 'Separator' };
     }
@@ -114,14 +116,18 @@ async function inferNode(node: any): Promise<InferredBlock | null> {
         };
     }
 
-    if (node.type === 'TEXT') return inferTextNode(node);
+    if (node.type === 'TEXT') return inferTextNode(node, skippedLayers);
     if (node.type === 'FRAME') return inferFrameNode(node);
 
     return null;
 }
 
-async function inferTextNode(node: any): Promise<InferredBlock | null> {
+async function inferTextNode(node: any, skippedLayers?: Array<{ name: string; reason: string }>): Promise<InferredBlock | null> {
     const styleId = await node.getTextStyleIdAsync();
+    if (styleId === (figma as any).mixed) {
+        skippedLayers?.push({ name: node.name || '(unnamed)', reason: 'Mixed text styles not supported' });
+        return null;
+    }
     const style = styleId ? await figma.getStyleByIdAsync(styleId) : null;
     const styleName: string = (style as any)?.name ?? '';
     const mapping = STYLE_TO_BLOCK[styleName];
@@ -224,7 +230,7 @@ function inferTableFrame(node: any): InferredBlock {
         }
         if (rowCells.length > 0) rows.push(rowCells);
     }
-    if (rows.length === 0) return { text: '', blockType: 'table', label: 'Table' };
+    if (rows.length === 0) return { text: '', blockType: 'table', label: 'Table', fidelityWarning: 'Empty table — no content to export' };
     const toRow = (cells: string[]) => `| ${cells.join(' | ')} |`;
     const sep = rows[0].map(() => '---');
     return {
@@ -276,6 +282,7 @@ function guessBlockType(text: string): string {
     if (text.startsWith('```'))  return 'code';
     if (text.startsWith('$$'))   return 'math';
     if (text.startsWith('|'))    return 'table';
+    if (/^#{4,6} /.test(text)) return 'heading-other';  // h4-h6 not rendered, but classifiable
     return 'paragraph';
 }
 
@@ -287,52 +294,88 @@ function guessBlockType(text: string): string {
  * @param inferredBlocks - Output of inferBlocksFromFrame.
  */
 export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[]): ExportBlock[] {
+    // Build fingerprint → available source indices map
     const sourceByFingerprint = new Map<string, number[]>();
-    for (let idx = 0; idx < sourceLines.length; idx++) {
-        const line = sourceLines[idx];
-        const fp = fingerprintBlock(guessBlockType(line), line);
+    for (let i = 0; i < sourceLines.length; i++) {
+        const line = sourceLines[i];
+        const type = guessBlockType(line);
+        const fp = fingerprintBlock(type, line);
         const existing = sourceByFingerprint.get(fp);
         if (existing) {
-            existing.push(idx);
+            existing.push(i);
         } else {
-            sourceByFingerprint.set(fp, [idx]);
+            sourceByFingerprint.set(fp, [i]);
         }
     }
 
-    // First pass: identify which source indices will be consumed by content-hash matches
-    const sourceIndicesUsedByContentHash = new Set<number>();
-    for (const inferred of inferredBlocks) {
-        const fp = fingerprintBlock(inferred.blockType, inferred.text);
-        const indices = sourceByFingerprint.get(fp);
-        if (indices && indices.length > 0) {
-            sourceIndicesUsedByContentHash.add(indices[0]);
+    // Pre-compute which source indices will be claimed by content-hash matches,
+    // so the position fallback does not steal them.
+    const reservedForContentHash = new Set<number>();
+    {
+        const tempUsed = new Set<number>();
+        for (const inferred of inferredBlocks) {
+            const fp = fingerprintBlock(inferred.blockType, inferred.text);
+            const indices = sourceByFingerprint.get(fp);
+            if (indices) {
+                for (let k = 0; k < indices.length; k++) {
+                    if (!tempUsed.has(indices[k])) {
+                        reservedForContentHash.add(indices[k]);
+                        tempUsed.add(indices[k]);
+                        break;
+                    }
+                }
+            }
         }
     }
 
     const usedSourceIndices = new Set<number>();
     const result: ExportBlock[] = [];
 
-    for (let i = 0; i < inferredBlocks.length; i++) {
-        const inferred = inferredBlocks[i];
+    for (let j = 0; j < inferredBlocks.length; j++) {
+        const inferred = inferredBlocks[j];
         const fp = fingerprintBlock(inferred.blockType, inferred.text);
+        const indices = sourceByFingerprint.get(fp);
 
-        const fpIndices = sourceByFingerprint.get(fp);
-        if (fpIndices && fpIndices.length > 0) {
-            const matchedIdx = fpIndices.shift()!;
-            if (fpIndices.length === 0) sourceByFingerprint.delete(fp);
-            const originalText = sourceLines[matchedIdx];
+        // Find first unused source index with matching fingerprint
+        let matchedSourceIndex: number | undefined;
+        if (indices) {
+            for (let k = 0; k < indices.length; k++) {
+                if (!usedSourceIndices.has(indices[k])) {
+                    matchedSourceIndex = indices[k];
+                    usedSourceIndices.add(matchedSourceIndex);
+                    break;
+                }
+            }
+        }
+
+        if (matchedSourceIndex !== undefined) {
+            // Content-hash match — unchanged
+            const originalText = sourceLines[matchedSourceIndex];
             result.push({ state: 'unchanged', originalText, inferredText: inferred.text });
-            continue;
+        } else {
+            // No content match — try position fallback, but only if not reserved for a later content-hash match
+            const sourceAtPosition = sourceLines[j];
+            if (
+                sourceAtPosition !== undefined &&
+                !usedSourceIndices.has(j) &&
+                !reservedForContentHash.has(j) &&
+                guessBlockType(sourceAtPosition) === inferred.blockType
+            ) {
+                usedSourceIndices.add(j);
+                result.push({
+                    state: 'modified',
+                    originalText: sourceAtPosition,
+                    inferredText: inferred.text,
+                    fidelityWarning: inferred.fidelityWarning,
+                });
+            } else {
+                result.push({
+                    state: 'new',
+                    inferredText: inferred.text,
+                    fidelityWarning: inferred.fidelityWarning,
+                });
+            }
         }
-
-        const sourceLine = sourceLines[i];
-        if (sourceLine !== undefined && guessBlockType(sourceLine) === inferred.blockType && !usedSourceIndices.has(i) && !sourceIndicesUsedByContentHash.has(i)) {
-            usedSourceIndices.add(i);
-            result.push({ state: 'modified', originalText: sourceLine, inferredText: inferred.text, fidelityWarning: inferred.fidelityWarning });
-            continue;
-        }
-
-        result.push({ state: 'new', inferredText: inferred.text, fidelityWarning: inferred.fidelityWarning });
     }
 
     return result;
@@ -349,7 +392,7 @@ export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[
  * For 'new' blocks: useOriginal = true means "skip this block".
  * Blocks are joined with a single blank line between them.
  */
-export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelection[]): string {
+export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelection[] = []): string {
     const selMap = new Map(selections.map(s => [s.blockIndex, s.useOriginal]));
     const lines: string[] = [];
 

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -13,19 +13,24 @@
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+export type BlockType =
+    | 'heading-1' | 'heading-2' | 'heading-3' | 'heading-other'
+    | 'paragraph' | 'code' | 'quote'
+    | 'list' | 'listGroup' | 'listItem'
+    | 'separator' | 'image' | 'table' | 'toc' | 'callout'
+    | 'definitionList' | 'footnoteSection' | 'badgeRow' | 'mermaid' | 'math';
+
 export interface InferredBlock {
     text: string;
-    blockType: string;
+    blockType: BlockType;
     label: string;
     fidelityWarning?: string;
 }
 
-export interface ExportBlock {
-    state: 'unchanged' | 'modified' | 'new';
-    originalText?: string;
-    inferredText: string;
-    fidelityWarning?: string;
-}
+export type ExportBlock =
+    | { state: 'unchanged'; originalText: string;  inferredText: string }
+    | { state: 'modified';  originalText: string;  inferredText: string; fidelityWarning?: string }
+    | { state: 'new';                              inferredText: string; fidelityWarning?: string };
 
 export interface ExportFrameResult {
     frameId: string;
@@ -49,13 +54,13 @@ export function normalizeContent(text: string): string {
 }
 
 /** Produces a stable fingerprint: "type:normalizedContent" */
-export function fingerprintBlock(blockType: string, content: string): string {
+export function fingerprintBlock(blockType: BlockType, content: string): string {
     return `${blockType}:${normalizeContent(content)}`;
 }
 
 // ─── Style name → block type mapping ─────────────────────────────────────────
 
-const STYLE_TO_BLOCK: Record<string, { blockType: string; label: string; prefix: string }> = {
+const STYLE_TO_BLOCK: Record<string, { blockType: BlockType; label: string; prefix: string }> = {
     'Markdown/H1':    { blockType: 'heading-1', label: 'Heading 1',  prefix: '# '  },
     'Markdown/H2':    { blockType: 'heading-2', label: 'Heading 2',  prefix: '## ' },
     'Markdown/H3':    { blockType: 'heading-3', label: 'Heading 3',  prefix: '### '},
@@ -65,7 +70,7 @@ const STYLE_TO_BLOCK: Record<string, { blockType: string; label: string; prefix:
     'Markdown/List':  { blockType: 'list',      label: 'List Item',  prefix: '- '  },
 };
 
-const FRAME_NAME_TO_BLOCK: Record<string, string> = {
+const FRAME_NAME_TO_BLOCK: Record<string, BlockType> = {
     'Table':             'table',
     'List Group':        'listGroup',
     'Table of Contents': 'toc',
@@ -130,8 +135,14 @@ async function inferTextNode(node: any, skippedLayers?: Array<{ name: string; re
     }
     const style = styleId ? await figma.getStyleByIdAsync(styleId) : null;
     const styleName: string = (style as any)?.name ?? '';
-    const mapping = STYLE_TO_BLOCK[styleName];
-    if (!mapping) return null;
+    const mapping = STYLE_TO_BLOCK[styleName as keyof typeof STYLE_TO_BLOCK];
+    if (!mapping) {
+        skippedLayers?.push({
+            name: node.name || '(unnamed)',
+            reason: `Text style "${styleName}" is not a Markdown/* style`,
+        });
+        return null;
+    }
 
     const text = node.characters as string;
     if (mapping.blockType === 'code') {
@@ -270,13 +281,13 @@ function inferBadgeRowFrame(node: any): InferredBlock {
  * Heuristic: infer block type from Markdown text prefix, for fingerprinting
  * source lines that were not produced by the inference engine.
  */
-function guessBlockType(text: string): string {
+function guessBlockType(text: string): BlockType {
     if (text.startsWith('# '))   return 'heading-1';
     if (text.startsWith('## '))  return 'heading-2';
     if (text.startsWith('### ')) return 'heading-3';
     if (text.startsWith('> [!')) return 'callout';
     if (text.startsWith('> '))   return 'quote';
-    if (text.startsWith('- ') || /^\d+\. /.test(text)) return 'listItem';
+    if (text.startsWith('- ') || /^\d+\. /.test(text)) return 'list';
     if (text.startsWith('---'))  return 'separator';
     if (text.startsWith('```mermaid')) return 'mermaid';
     if (text.startsWith('```'))  return 'code';
@@ -289,6 +300,10 @@ function guessBlockType(text: string): string {
 /**
  * Diffs source Markdown strings against inferred blocks using content-hash
  * matching with position+type as fallback.
+ *
+ * Uses a pre-pass to reserve source indices for content-hash matches before
+ * running the position fallback, preventing the fallback from consuming an
+ * index needed by a later hash match.
  *
  * @param sourceLines - Markdown strings from stored pluginData, split by double-newline.
  * @param inferredBlocks - Output of inferBlocksFromFrame.
@@ -309,7 +324,9 @@ export function diffBlocks(sourceLines: string[], inferredBlocks: InferredBlock[
     }
 
     // Pre-compute which source indices will be claimed by content-hash matches,
-    // so the position fallback does not steal them.
+    // so the position fallback does not steal them. Without this, the position
+    // fallback could consume a source index that a later content-hash match needs,
+    // producing a spurious 'modified' instead of 'unchanged'.
     const reservedForContentHash = new Set<number>();
     {
         const tempUsed = new Set<number>();
@@ -402,10 +419,10 @@ export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelecti
         let text: string;
 
         if (block.state === 'unchanged') {
-            text = block.originalText!;
+            text = block.originalText;
         } else if (block.state === 'modified') {
             const useOriginal = override !== undefined ? override : true;
-            text = useOriginal ? block.originalText! : block.inferredText;
+            text = useOriginal ? block.originalText : block.inferredText;
         } else {
             if (override === true) continue;
             text = block.inferredText;
@@ -418,7 +435,7 @@ export function assembleMarkdown(blocks: ExportBlock[], selections: BlockSelecti
 }
 
 /**
- * Runs the full 4-stage export pipeline for a single Figma FrameNode.
+ * Runs the full 3-stage export pipeline for a single Figma FrameNode.
  * Returns an ExportFrameResult ready to send to the UI via postMessage.
  */
 export async function exportFrame(frame: any): Promise<ExportFrameResult> {

--- a/figma-markdown-sync/exporter.ts
+++ b/figma-markdown-sync/exporter.ts
@@ -1,0 +1,270 @@
+/**
+ * exporter.ts
+ *
+ * Figma → Markdown export pipeline.
+ *
+ * Stages:
+ *   1. inferBlocksFromFrame  — walk layer tree, produce InferredBlock[]
+ *   2. diffBlocks            — compare inferred vs stored source blocks
+ *   3. assembleMarkdown      — merge diff result into final Markdown string
+ *
+ * This module only reads existing Figma nodes — no rendering occurs here.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface InferredBlock {
+    text: string;
+    blockType: string;
+    label: string;
+    fidelityWarning?: string;
+}
+
+export interface DiffBlock {
+    state: 'unchanged' | 'modified' | 'new';
+    originalText?: string;
+    inferredText: string;
+    label: string;
+    fidelityWarning?: string;
+}
+
+export interface ExportFrameResult {
+    frameId: string;
+    filename: string;
+    hasStoredSource: boolean;
+    sourceTruncated: boolean;
+    blocks: DiffBlock[];
+    skippedLayers: Array<{ name: string; reason: string }>;
+}
+
+export interface BlockSelection {
+    blockIndex: number;
+    useOriginal: boolean;
+}
+
+// ─── Helpers (exported for testing) ──────────────────────────────────────────
+
+/** Strips leading/trailing whitespace and collapses internal runs to one space. */
+export function normalizeContent(text: string): string {
+    return text.trim().replace(/\s+/g, ' ');
+}
+
+/** Produces a stable fingerprint: "type:normalizedContent" */
+export function fingerprintBlock(blockType: string, content: string): string {
+    return `${blockType}:${normalizeContent(content)}`;
+}
+
+// ─── Style name → block type mapping ─────────────────────────────────────────
+
+const STYLE_TO_BLOCK: Record<string, { blockType: string; label: string; prefix: string }> = {
+    'Markdown/H1':    { blockType: 'heading-1', label: 'Heading 1',  prefix: '# '  },
+    'Markdown/H2':    { blockType: 'heading-2', label: 'Heading 2',  prefix: '## ' },
+    'Markdown/H3':    { blockType: 'heading-3', label: 'Heading 3',  prefix: '### '},
+    'Markdown/Body':  { blockType: 'paragraph', label: 'Paragraph',  prefix: ''    },
+    'Markdown/Code':  { blockType: 'code',      label: 'Code Block', prefix: ''    },
+    'Markdown/Quote': { blockType: 'quote',     label: 'Blockquote', prefix: '> '  },
+    'Markdown/List':  { blockType: 'list',      label: 'List Item',  prefix: '- '  },
+};
+
+const FRAME_NAME_TO_BLOCK: Record<string, string> = {
+    'Table':             'table',
+    'List Group':        'listGroup',
+    'Table of Contents': 'toc',
+    'Definition List':   'definitionList',
+    'Footnotes':         'footnoteSection',
+    'Badge Row':         'badgeRow',
+    'Mermaid Diagram':   'mermaid',
+    'Math Block':        'math',
+};
+
+// ─── Inference ────────────────────────────────────────────────────────────────
+
+interface InferenceResult {
+    blocks: InferredBlock[];
+    skippedLayers: Array<{ name: string; reason: string }>;
+}
+
+export async function inferBlocksFromFrame(frame: any): Promise<InferenceResult> {
+    const blocks: InferredBlock[] = [];
+    const skippedLayers: Array<{ name: string; reason: string }> = [];
+
+    for (const child of (frame.children ?? [])) {
+        const inferred = await inferNode(child);
+        if (inferred) {
+            blocks.push(inferred);
+        } else {
+            skippedLayers.push({ name: child.name || '(unnamed)', reason: 'Unrecognized layer type or name' });
+        }
+    }
+
+    return { blocks, skippedLayers };
+}
+
+async function inferNode(node: any): Promise<InferredBlock | null> {
+    if (node.type === 'RECTANGLE' && node.height === 1) {
+        return { text: '---', blockType: 'separator', label: 'Separator' };
+    }
+
+    if (node.type === 'RECTANGLE' && node.height > 1 &&
+        Array.isArray(node.fills) && node.fills[0]?.type === 'IMAGE') {
+        return {
+            text: `![${node.name || 'image'}](image-not-recoverable)`,
+            blockType: 'image',
+            label: 'Image',
+            fidelityWarning: 'Image URL not recoverable — update the URL manually after export.',
+        };
+    }
+
+    if (node.type === 'TEXT') return inferTextNode(node);
+    if (node.type === 'FRAME') return inferFrameNode(node);
+
+    return null;
+}
+
+async function inferTextNode(node: any): Promise<InferredBlock | null> {
+    const styleId = await node.getTextStyleIdAsync();
+    const style = styleId ? await figma.getStyleByIdAsync(styleId) : null;
+    const styleName: string = (style as any)?.name ?? '';
+    const mapping = STYLE_TO_BLOCK[styleName];
+    if (!mapping) return null;
+
+    const text = node.characters as string;
+    if (mapping.blockType === 'code') {
+        return { text: `\`\`\`\n${text}\n\`\`\``, blockType: 'code', label: 'Code Block' };
+    }
+    return { text: mapping.prefix + text, blockType: mapping.blockType, label: mapping.label };
+}
+
+async function inferFrameNode(node: any): Promise<InferredBlock | null> {
+    const blockType = FRAME_NAME_TO_BLOCK[node.name];
+
+    if (!blockType) {
+        if (node.name?.startsWith('Callout: ')) return inferCalloutFrame(node);
+        return null;
+    }
+
+    switch (blockType) {
+        case 'table':           return inferTableFrame(node);
+        case 'listGroup':       return inferListGroupFrame(node);
+        case 'mermaid':         return inferMermaidFrame(node);
+        case 'math':            return inferMathFrame(node);
+        case 'definitionList':  return inferDefinitionListFrame(node);
+        case 'footnoteSection': return inferFootnotesFrame(node);
+        case 'badgeRow':        return inferBadgeRowFrame(node);
+        case 'toc':
+            return {
+                text: '',
+                blockType: 'toc',
+                label: 'Table of Contents',
+                fidelityWarning: 'TOC is auto-generated on re-import — skipped in export output.',
+            };
+        default: return null;
+    }
+}
+
+function inferMermaidFrame(node: any): InferredBlock {
+    const source: string = node.getPluginData('mermaidSource');
+    return {
+        text: `\`\`\`mermaid\n${source}\n\`\`\``,
+        blockType: 'mermaid',
+        label: 'Mermaid Diagram',
+        fidelityWarning: source.length === 0 ? 'Mermaid source not recoverable — original source used if available.' : undefined,
+    };
+}
+
+function inferMathFrame(node: any): InferredBlock {
+    const source: string = node.getPluginData('mathSource');
+    return {
+        text: `$$\n${source}\n$$`,
+        blockType: 'math',
+        label: 'Math Block',
+        fidelityWarning: source.length === 0 ? 'Math source not recoverable — original source used if available.' : undefined,
+    };
+}
+
+function inferCalloutFrame(node: any): InferredBlock {
+    const typeLabel = node.name.replace('Callout: ', '').toUpperCase();
+    const bodyLines: string[] = [];
+    for (const child of (node.children ?? [])) {
+        if (child.type === 'TEXT' && child.characters) {
+            bodyLines.push(`> ${child.characters}`);
+        }
+    }
+    return {
+        text: `> [!${typeLabel}]\n${bodyLines.join('\n')}`,
+        blockType: 'callout',
+        label: `Callout (${typeLabel})`,
+    };
+}
+
+async function inferListGroupFrame(node: any): Promise<InferredBlock> {
+    const lines: string[] = [];
+    for (const child of (node.children ?? [])) {
+        if (child.type === 'TEXT') {
+            lines.push(`- ${child.characters}`);
+        } else if (child.type === 'FRAME') {
+            for (const grandchild of (child.children ?? [])) {
+                if (grandchild.type === 'TEXT' && grandchild.characters) {
+                    const isChecked = child.name === 'Task (done)';
+                    lines.push(`- [${isChecked ? 'x' : ' '}] ${grandchild.characters}`);
+                    break;
+                }
+            }
+        }
+    }
+    return { text: lines.join('\n'), blockType: 'listGroup', label: 'List' };
+}
+
+function inferTableFrame(node: any): InferredBlock {
+    const rows: string[][] = [];
+    for (const child of (node.children ?? [])) {
+        const rowCells: string[] = [];
+        for (const cell of (child.children ?? [])) {
+            const textNode = (cell.children ?? []).find((n: any) => n.type === 'TEXT');
+            rowCells.push(textNode?.characters ?? '');
+        }
+        if (rowCells.length > 0) rows.push(rowCells);
+    }
+    if (rows.length === 0) return { text: '', blockType: 'table', label: 'Table' };
+    const toRow = (cells: string[]) => `| ${cells.join(' | ')} |`;
+    const sep = rows[0].map(() => '---');
+    return {
+        text: [toRow(rows[0]), toRow(sep), ...rows.slice(1).map(toRow)].join('\n'),
+        blockType: 'table',
+        label: 'Table',
+    };
+}
+
+function inferDefinitionListFrame(node: any): InferredBlock {
+    const lines: string[] = [];
+    const texts = (node.children ?? []).filter((n: any) => n.type === 'TEXT');
+    for (let i = 0; i < texts.length; i += 2) {
+        if (texts[i]) lines.push(texts[i].characters);
+        if (texts[i + 1]) lines.push(`: ${texts[i + 1].characters}`);
+    }
+    return { text: lines.join('\n'), blockType: 'definitionList', label: 'Definition List' };
+}
+
+function inferFootnotesFrame(node: any): InferredBlock {
+    const lines: string[] = [];
+    const texts = (node.children ?? []).filter((n: any) => n.type === 'TEXT');
+    texts.forEach((t: any, i: number) => { lines.push(`[^${i + 1}]: ${t.characters}`); });
+    return { text: lines.join('\n'), blockType: 'footnoteSection', label: 'Footnotes' };
+}
+
+function inferBadgeRowFrame(node: any): InferredBlock {
+    const badges = (node.children ?? [])
+        .filter((c: any) => c.name?.startsWith('Badge: '))
+        .map((c: any) => `[badge:${c.name.replace('Badge: ', '')}]`);
+    return { text: badges.join(' '), blockType: 'badgeRow', label: 'Badge Row' };
+}
+
+// ─── Placeholder stubs (implemented in later tasks) ──────────────────────────
+
+export function diffBlocks(_sourceLines: string[], _inferredBlocks: InferredBlock[]): DiffBlock[] {
+    throw new Error('diffBlocks not yet implemented');
+}
+
+export function assembleMarkdown(_blocks: DiffBlock[], _selections: BlockSelection[]): string {
+    throw new Error('assembleMarkdown not yet implemented');
+}

--- a/figma-markdown-sync/messages.ts
+++ b/figma-markdown-sync/messages.ts
@@ -37,3 +37,7 @@ export const MSG_GET_SELECTION   = 'get-selection';    // UI asks sandbox for cu
 export const MSG_EXPORT_RESULT      = 'export-result';      // Sandbox returns diff result per frame
 export const MSG_EXPORT_MARKDOWN    = 'export-markdown';    // Sandbox returns assembled Markdown string
 export const MSG_SELECTION_CHANGED  = 'selection-changed';  // Sandbox notifies UI of frame selection change
+
+// ── Status message domain tags ───────────────────────────────────────────────
+
+export const STATUS_DOMAIN_EXPORT = 'export';  // MSG_STATUS messages from the export pipeline

--- a/figma-markdown-sync/messages.ts
+++ b/figma-markdown-sync/messages.ts
@@ -25,3 +25,15 @@ export const MSG_SETTINGS         = 'settings';
 export const MSG_LOCAL_STYLES     = 'local-styles';
 export const MSG_LOCAL_COMPONENTS = 'local-components';
 export const MSG_HISTORY          = 'history';
+
+// ── Export (UI → Sandbox) ────────────────────────────────────────────────────
+
+export const MSG_EXPORT_REQUEST  = 'export-request';   // UI sends selected frame IDs
+export const MSG_EXPORT_DOWNLOAD = 'export-download';  // UI sends frame ID + block selections
+export const MSG_GET_SELECTION   = 'get-selection';    // UI asks sandbox for current selection
+
+// ── Export (Sandbox → UI) ────────────────────────────────────────────────────
+
+export const MSG_EXPORT_RESULT      = 'export-result';      // Sandbox returns diff result per frame
+export const MSG_EXPORT_MARKDOWN    = 'export-markdown';    // Sandbox returns assembled Markdown string
+export const MSG_SELECTION_CHANGED  = 'selection-changed';  // Sandbox notifies UI of frame selection change

--- a/figma-markdown-sync/src/styles.css
+++ b/figma-markdown-sync/src/styles.css
@@ -636,3 +636,133 @@ button {
     color: #888;
     margin-top: 2px;
 }
+
+/* ── Export Panel ─────────────────────────────────────────────────────────── */
+
+.export-empty {
+    padding: 24px 16px;
+    color: var(--figma-color-text-secondary, #666);
+    text-align: center;
+    font-size: 13px;
+}
+
+#export-frame-info {
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 8px;
+}
+
+#export-block-counts {
+    font-size: 12px;
+    margin-bottom: 16px;
+    color: var(--figma-color-text-secondary, #555);
+}
+
+.export-warning {
+    font-size: 12px;
+    color: #9a6700;
+    margin-bottom: 12px;
+}
+
+#export-actions {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.btn-primary {
+    background: var(--figma-color-bg-brand, #18a0fb);
+    color: white;
+    border: none;
+    font-size: 12px;
+    padding: 7px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.btn-primary:hover:not(:disabled) { background: #0d8de0; }
+.btn-primary:disabled { background: #B0C4CE; cursor: default; }
+
+/* ── Review Mode ──────────────────────────────────────────────────────────── */
+
+.review-block {
+    border: 1px solid var(--figma-color-border, #e0e0e0);
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 12px;
+}
+
+.review-block--modified { border-left: 3px solid #9a6700; }
+.review-block--new      { border-left: 3px solid #0969da; }
+
+.review-block-header {
+    font-weight: 600;
+    font-size: 12px;
+    margin-bottom: 8px;
+}
+
+.review-fidelity-warning {
+    font-size: 11px;
+    color: #9a6700;
+    margin-bottom: 8px;
+}
+
+.review-diff {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.review-diff-col { flex: 1; min-width: 0; }
+
+.review-diff-header {
+    font-size: 11px;
+    color: #666;
+    margin-bottom: 4px;
+}
+
+.review-diff-text {
+    font-size: 11px;
+    font-family: 'Roboto Mono', monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: var(--figma-color-bg-secondary, #f5f5f5);
+    border-radius: 4px;
+    padding: 6px 8px;
+    margin: 0;
+}
+
+.review-block-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.btn-review {
+    font-size: 11px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--figma-color-border, #ccc);
+    background: transparent;
+    cursor: pointer;
+}
+
+.btn-review--active {
+    background: var(--figma-color-bg-brand, #18a0fb);
+    color: white;
+    border-color: transparent;
+}
+
+#export-review-back {
+    background: none;
+    border: none;
+    color: var(--figma-color-text-brand, #0969da);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 0;
+    margin-top: 12px;
+    display: block;
+}
+
+#export-log-panel { margin-top: 16px; }
+#export-log-content { font-size: 11px; font-family: monospace; white-space: pre-wrap; }

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -6,7 +6,10 @@ import {
     MSG_GET_LOCAL_STYLES, MSG_GET_LOCAL_COMPONENTS,
     MSG_GET_HISTORY, MSG_CLEAR_HISTORY, MSG_IMPORT_BATCH,
     MSG_STATUS, MSG_SETTINGS, MSG_LOCAL_STYLES, MSG_LOCAL_COMPONENTS, MSG_HISTORY,
+    MSG_EXPORT_REQUEST, MSG_EXPORT_DOWNLOAD, MSG_GET_SELECTION,
+    MSG_EXPORT_RESULT, MSG_EXPORT_MARKDOWN, MSG_SELECTION_CHANGED,
 } from '../messages';
+import type { ExportBlock, BlockSelection, ExportFrameResult } from '../exporter';
 
 function escapeHtml(str: string): string {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -68,6 +71,22 @@ const styleBindingSelects = document.querySelectorAll<HTMLSelectElement>('.style
 // Component binding selects
 const componentBindingSelects = document.querySelectorAll<HTMLSelectElement>('.component-binding-select');
 
+// Export tab elements
+const exportNoSelection      = document.getElementById('export-no-selection') as HTMLElement;
+const exportFrameSummary     = document.getElementById('export-frame-summary') as HTMLElement;
+const exportFrameInfo        = document.getElementById('export-frame-info') as HTMLElement;
+const exportBlockCounts      = document.getElementById('export-block-counts') as HTMLElement;
+const exportTruncatedWarning = document.getElementById('export-truncated-warning') as HTMLElement;
+const exportBtn              = document.getElementById('export-btn') as HTMLButtonElement;
+const exportReviewBtn        = document.getElementById('export-review-btn') as HTMLButtonElement;
+const exportReviewPanel      = document.getElementById('export-review-panel') as HTMLElement;
+const exportReviewBreadcrumb = document.getElementById('export-review-breadcrumb') as HTMLElement;
+const exportReviewBlocks     = document.getElementById('export-review-blocks') as HTMLElement;
+const exportReviewBack       = document.getElementById('export-review-back') as HTMLButtonElement;
+const exportConfirmBtn       = document.getElementById('export-confirm-btn') as HTMLButtonElement;
+const exportLogPanel         = document.getElementById('export-log-panel') as HTMLElement;
+const exportLogContent       = document.getElementById('export-log-content') as HTMLElement;
+
 // Theme presets (duplicated from settings.ts — UI runs in a separate iframe bundle).
 // IMPORTANT: Keep in sync with THEME_PRESETS in settings.ts.
 const THEME_PRESETS: Record<string, Record<string, unknown>> = {
@@ -92,6 +111,205 @@ const THEME_PRESETS: Record<string, Record<string, unknown>> = {
 
 let currentFiles: { name: string; content: string }[] = [];
 
+// Export state
+let exportFrameResults: ExportFrameResult[] = [];
+let exportReviewSelections: Map<number, Map<number, boolean>> = new Map();
+let exportCurrentFrameIndex = 0;
+let pendingDownloadIndex = 0;
+
+// ── Export UI helpers ────────────────────────────────────────────────────────
+
+function showExportNoSelection() {
+    exportNoSelection.hidden = false;
+    exportFrameSummary.hidden = true;
+    exportReviewPanel.hidden = true;
+}
+
+function renderExportSummary(frames: ExportFrameResult[]) {
+    exportFrameResults = frames;
+    exportReviewSelections = new Map();
+    exportNoSelection.hidden = true;
+    exportReviewPanel.hidden = true;
+
+    if (frames.length === 0) { showExportNoSelection(); return; }
+
+    exportFrameSummary.hidden = false;
+    const frame = frames[0];
+
+    exportFrameInfo.textContent = frames.length === 1
+        ? `"${frame.filename.replace('.md', '')}"`
+        : `${frames.length} frames selected`;
+
+    exportTruncatedWarning.hidden = !frame.sourceTruncated;
+
+    const unchanged = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'unchanged').length, 0);
+    const modified  = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'modified').length, 0);
+    const added     = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'new').length, 0);
+
+    if (!frame.hasStoredSource && frames.length === 1) {
+        exportBlockCounts.textContent = added === 0
+            ? 'No Markdown content detected. This frame may not use Markdown/* styles.'
+            : `${added} block${added !== 1 ? 's' : ''} inferred`;
+        exportBtn.disabled = added === 0;
+        exportReviewBtn.hidden = true;
+    } else {
+        const parts = [
+            unchanged > 0 ? `${unchanged} unchanged ✓` : '',
+            modified  > 0 ? `${modified} modified ↻`  : '',
+            added     > 0 ? `${added} added +`         : '',
+        ].filter(Boolean);
+        exportBlockCounts.textContent = parts.join('  ');
+        exportBtn.disabled = false;
+        exportBtn.textContent = frames.length > 1 ? `Export all (${frames.length} files)` : 'Export .md';
+        exportReviewBtn.hidden = (modified + added) === 0;
+    }
+}
+
+function renderReviewPanel(frameIndex: number) {
+    exportCurrentFrameIndex = frameIndex;
+    const frame = exportFrameResults[frameIndex];
+    if (!frame) return;
+
+    exportFrameSummary.hidden = true;
+    exportReviewPanel.hidden = false;
+
+    if (exportFrameResults.length > 1) {
+        exportReviewBreadcrumb.textContent = `Frame ${frameIndex + 1} of ${exportFrameResults.length}: ${frame.filename}`;
+        exportReviewBreadcrumb.hidden = false;
+    } else {
+        exportReviewBreadcrumb.hidden = true;
+    }
+
+    // Clear existing content using safe DOM method
+    while (exportReviewBlocks.firstChild) exportReviewBlocks.removeChild(exportReviewBlocks.firstChild);
+
+    const reviewable = frame.blocks.filter(b => b.state !== 'unchanged');
+    const frameSelections = exportReviewSelections.get(frameIndex) ?? new Map<number, boolean>();
+
+    reviewable.forEach(block => {
+        const blockIndex = frame.blocks.indexOf(block);
+        const defaultUseOriginal = block.state === 'modified';
+        const useOriginal = frameSelections.has(blockIndex) ? frameSelections.get(blockIndex)! : defaultUseOriginal;
+
+        const el = document.createElement('div');
+        el.className = `review-block review-block--${block.state}`;
+
+        // Header - use block state as label (ExportBlock has no label field)
+        const header = document.createElement('div');
+        header.className = 'review-block-header';
+        const stateIcon = block.state === 'modified' ? '↻' : '+';
+        const stateLabel = block.state === 'modified' ? 'modified' : 'added';
+        header.textContent = `${stateIcon} ${stateLabel}`;
+        el.appendChild(header);
+
+        // Fidelity warning (fidelityWarning is our own string, not user input — textContent still fine)
+        if (block.fidelityWarning) {
+            const warn = document.createElement('div');
+            warn.className = 'review-fidelity-warning';
+            warn.textContent = `⚠ ${block.fidelityWarning}`;
+            el.appendChild(warn);
+        }
+
+        // Diff panes
+        const diff = document.createElement('div');
+        diff.className = 'review-diff';
+
+        if (block.originalText !== undefined) {
+            const origCol = document.createElement('div');
+            origCol.className = 'review-diff-col';
+            const origLabel = document.createElement('div');
+            origLabel.className = 'review-diff-header';
+            origLabel.textContent = 'Original';
+            const origPre = document.createElement('pre');
+            origPre.className = 'review-diff-text';
+            origPre.textContent = block.originalText;
+            origCol.appendChild(origLabel);
+            origCol.appendChild(origPre);
+            diff.appendChild(origCol);
+        }
+
+        const currCol = document.createElement('div');
+        currCol.className = 'review-diff-col';
+        const currLabel = document.createElement('div');
+        currLabel.className = 'review-diff-header';
+        currLabel.textContent = 'Current';
+        const currPre = document.createElement('pre');
+        currPre.className = 'review-diff-text';
+        currPre.textContent = block.inferredText;
+        currCol.appendChild(currLabel);
+        currCol.appendChild(currPre);
+        diff.appendChild(currCol);
+        el.appendChild(diff);
+
+        // Action buttons
+        const actions = document.createElement('div');
+        actions.className = 'review-block-actions';
+
+        const makeBtn = (label: string, blockIdx: number, useOrig: boolean, active: boolean) => {
+            const btn = document.createElement('button');
+            btn.className = `btn-review${active ? ' btn-review--active' : ''}`;
+            btn.textContent = label;
+            btn.addEventListener('click', () => {
+                const sel = exportReviewSelections.get(frameIndex) ?? new Map<number, boolean>();
+                sel.set(blockIdx, useOrig);
+                exportReviewSelections.set(frameIndex, sel);
+                renderReviewPanel(frameIndex);
+            });
+            return btn;
+        };
+
+        if (block.state === 'modified') {
+            actions.appendChild(makeBtn('✓ Keep original', blockIndex, true, useOriginal));
+            actions.appendChild(makeBtn('Use current', blockIndex, false, !useOriginal));
+        } else {
+            actions.appendChild(makeBtn('✓ Include', blockIndex, false, !useOriginal));
+            actions.appendChild(makeBtn('Skip', blockIndex, true, useOriginal));
+        }
+
+        el.appendChild(actions);
+        exportReviewBlocks.appendChild(el);
+    });
+}
+
+function triggerDownload(filename: string, content: string) {
+    const blob = new Blob([content], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function downloadFrame(frameIndex: number) {
+    const frame = exportFrameResults[frameIndex];
+    if (!frame) return;
+    const sel = exportReviewSelections.get(frameIndex);
+    const selections: BlockSelection[] = sel
+        ? Array.from(sel.entries()).map(([blockIndex, useOriginal]) => ({ blockIndex, useOriginal }))
+        : [];
+    parent.postMessage({ pluginMessage: { type: MSG_EXPORT_DOWNLOAD, frameId: frame.frameId, selections } }, '*');
+}
+
+function startSequentialDownload() {
+    pendingDownloadIndex = 0;
+    downloadFrame(pendingDownloadIndex);
+}
+
+function renderExportLog(frames: ExportFrameResult[]) {
+    const lines: string[] = [];
+    for (const frame of frames) {
+        if (frame.skippedLayers && frame.skippedLayers.length > 0) {
+            lines.push(`--- ${frame.filename} ---`);
+            for (const s of frame.skippedLayers) {
+                lines.push(`  Skipped: "${s.name}" — ${s.reason}`);
+            }
+        }
+    }
+    exportLogPanel.hidden = lines.length === 0;
+    exportLogContent.textContent = lines.join('\n');
+}
+
 // ── Tab switching ───────────────────────────────────────────────────────────
 
 tabs.forEach(tab => {
@@ -111,6 +329,9 @@ tabs.forEach(tab => {
         }
         if (tab.dataset.tab === 'history') {
             parent.postMessage({ pluginMessage: { type: MSG_GET_HISTORY } }, '*');
+        }
+        if (tab.dataset.tab === 'export') {
+            parent.postMessage({ pluginMessage: { type: MSG_GET_SELECTION } }, '*');
         }
     });
 });
@@ -525,6 +746,16 @@ function sendCurrentSettings() {
 
 setupSettingListeners();
 
+// ── Export button listeners ──────────────────────────────────────────────────
+
+exportBtn.addEventListener('click', startSequentialDownload);
+exportReviewBtn.addEventListener('click', () => renderReviewPanel(0));
+exportReviewBack.addEventListener('click', () => {
+    exportReviewPanel.hidden = true;
+    exportFrameSummary.hidden = false;
+});
+exportConfirmBtn.addEventListener('click', () => downloadFrame(exportCurrentFrameIndex));
+
 // ── History ─────────────────────────────────────────────────────────────────
 
 const historyList = document.getElementById('history-list') as HTMLUListElement;
@@ -604,6 +835,28 @@ window.onmessage = event => {
             break;
         case MSG_HISTORY:
             renderHistory(msg.entries ?? []);
+            break;
+        case MSG_SELECTION_CHANGED: {
+            const activePanel = document.querySelector<HTMLElement>('.tab-panel:not([hidden])');
+            if (activePanel?.id === 'tab-export') {
+                if (msg.frameIds.length > 0) {
+                    parent.postMessage({ pluginMessage: { type: MSG_EXPORT_REQUEST, frameIds: msg.frameIds } }, '*');
+                } else {
+                    showExportNoSelection();
+                }
+            }
+            break;
+        }
+        case MSG_EXPORT_RESULT:
+            renderExportSummary(msg.frames);
+            renderExportLog(msg.frames);
+            break;
+        case MSG_EXPORT_MARKDOWN:
+            triggerDownload(msg.filename, msg.content);
+            pendingDownloadIndex++;
+            if (pendingDownloadIndex < exportFrameResults.length) {
+                setTimeout(() => downloadFrame(pendingDownloadIndex), 300);
+            }
             break;
         default:
             break;

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -126,8 +126,12 @@ function showExportNoSelection() {
 }
 
 function renderExportSummary(frames: ExportFrameResult[]) {
+    const incomingIds = frames.map(f => f.frameId).join(',');
+    const currentIds  = exportFrameResults.map(f => f.frameId).join(',');
+    if (incomingIds !== currentIds) {
+        exportReviewSelections = new Map();
+    }
     exportFrameResults = frames;
-    exportReviewSelections = new Map();
     exportNoSelection.hidden = true;
     exportReviewPanel.hidden = true;
 
@@ -147,9 +151,13 @@ function renderExportSummary(frames: ExportFrameResult[]) {
     const added     = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'new').length, 0);
 
     if (!frame.hasStoredSource && frames.length === 1) {
-        exportBlockCounts.textContent = added === 0
+        exportFrameInfo.textContent = 'No import history found.';
+
+        const countText = added === 0
             ? 'No Markdown content detected. This frame may not use Markdown/* styles.'
             : `${added} block${added !== 1 ? 's' : ''} inferred`;
+        exportBlockCounts.textContent = `Inference works best on frames using Markdown/* text styles. Other frames may produce few or no blocks.\n\n${countText}`;
+
         exportBtn.disabled = added === 0;
         exportReviewBtn.hidden = true;
     } else {

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -145,7 +145,7 @@ function renderExportSummary(frames: ExportFrameResult[]) {
         ? `"${frame.filename.replace('.md', '')}"`
         : `${frames.length} frames selected`;
 
-    exportTruncatedWarning.hidden = !frame.sourceTruncated;
+    exportTruncatedWarning.hidden = !frames.some(f => f.sourceTruncated);
 
     const unchanged = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'unchanged').length, 0);
     const modified  = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'modified').length, 0);
@@ -203,7 +203,6 @@ function renderReviewPanel(frameIndex: number) {
         const el = document.createElement('div');
         el.className = `review-block review-block--${block.state}`;
 
-        // Header - use block state as label (ExportBlock has no label field)
         const header = document.createElement('div');
         header.className = 'review-block-header';
         const stateIcon = block.state === 'modified' ? '↻' : '+';
@@ -211,7 +210,6 @@ function renderReviewPanel(frameIndex: number) {
         header.textContent = `${stateIcon} ${stateLabel}`;
         el.appendChild(header);
 
-        // Fidelity warning (fidelityWarning is our own string, not user input — textContent still fine)
         if (block.fidelityWarning) {
             const warn = document.createElement('div');
             warn.className = 'review-fidelity-warning';
@@ -223,7 +221,7 @@ function renderReviewPanel(frameIndex: number) {
         const diff = document.createElement('div');
         diff.className = 'review-diff';
 
-        if (block.originalText !== undefined) {
+        if (block.state === 'modified') {
             const origCol = document.createElement('div');
             origCol.className = 'review-diff-col';
             const origLabel = document.createElement('div');
@@ -280,14 +278,22 @@ function renderReviewPanel(frameIndex: number) {
     });
 }
 
-function triggerDownload(filename: string, content: string) {
-    const blob = new Blob([content], { type: 'text/markdown' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
+function triggerDownload(filename: string, content: string): boolean {
+    let url: string | null = null;
+    try {
+        const blob = new Blob([content], { type: 'text/markdown' });
+        url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        return true;
+    } catch (err) {
+        console.error('[MarkDown For What] Download failed:', err);
+        return false;
+    } finally {
+        if (url) URL.revokeObjectURL(url);
+    }
 }
 
 function downloadFrame(frameIndex: number) {
@@ -763,7 +769,7 @@ exportReviewBack.addEventListener('click', () => {
     exportReviewPanel.hidden = true;
     exportFrameSummary.hidden = false;
 });
-exportConfirmBtn.addEventListener('click', () => downloadFrame(exportCurrentFrameIndex));
+exportConfirmBtn.addEventListener('click', startSequentialDownload);
 
 // ── History ─────────────────────────────────────────────────────────────────
 
@@ -822,8 +828,8 @@ window.onmessage = event => {
             if (!previewPane.classList.contains('hidden')) hidePreview();
             importBtn.disabled = currentFiles.length === 0;
             showStatus(msg.message, msg.error ? 'error' : msg.warning ? 'warning' : 'success');
-            // Clear paste area on successful import
-            if (!msg.error) {
+            // Clear paste area on successful import (but not for export-domain status messages)
+            if (!msg.error && msg.domain !== 'export') {
                 pasteArea.value = '';
                 pasteName.value = '';
                 pasteImportBtn.disabled = true;
@@ -846,7 +852,7 @@ window.onmessage = event => {
             renderHistory(msg.entries ?? []);
             break;
         case MSG_SELECTION_CHANGED: {
-            const activePanel = document.querySelector<HTMLElement>('.tab-panel:not([hidden])');
+            const activePanel = document.querySelector<HTMLElement>('.tab-panel:not(.hidden)');
             if (activePanel?.id === 'tab-export') {
                 if (msg.frameIds.length > 0) {
                     parent.postMessage({ pluginMessage: { type: MSG_EXPORT_REQUEST, frameIds: msg.frameIds } }, '*');
@@ -860,13 +866,18 @@ window.onmessage = event => {
             renderExportSummary(msg.frames);
             renderExportLog(msg.frames);
             break;
-        case MSG_EXPORT_MARKDOWN:
-            triggerDownload(msg.filename, msg.content);
+        case MSG_EXPORT_MARKDOWN: {
+            const success = triggerDownload(msg.filename, msg.content);
+            if (!success) {
+                // triggerDownload already logged; show user-visible feedback via existing status mechanism
+                showStatus(`Failed to download ${msg.filename}`, 'error');
+            }
             pendingDownloadIndex++;
             if (pendingDownloadIndex < exportFrameResults.length) {
                 setTimeout(() => downloadFrame(pendingDownloadIndex), DOWNLOAD_STAGGER_MS);
             }
             break;
+        }
         default:
             break;
     }

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -114,10 +114,11 @@ let currentFiles: { name: string; content: string }[] = [];
 
 // Export state
 let exportFrameResults: ExportFrameResult[] = [];
-let exportReviewSelections: Map<number, Map<number, boolean>> = new Map();
+let exportReviewSelections: Map<number, Map<number, 'use-original' | 'use-inferred' | 'skip'>> = new Map();
 let exportCurrentFrameIndex = 0;
 let pendingDownloadIndex = 0;
-const DOWNLOAD_STAGGER_MS = 300; // delay between sequential downloads to avoid browser throttling
+let downloadBatchId = 0;
+const DOWNLOAD_STAGGER_MS = 300; // delay between triggering successive file downloads to avoid browser download-manager throttling
 
 // ── Export UI helpers ────────────────────────────────────────────────────────
 
@@ -146,13 +147,13 @@ function renderExportSummary(frames: ExportFrameResult[]) {
         ? `"${frame.filename.replace('.md', '')}"`
         : `${frames.length} frames selected`;
 
-    exportTruncatedWarning.hidden = !frames.some(f => f.sourceTruncated);
+    exportTruncatedWarning.hidden = !frames.some(f => f.sourceStatus === 'truncated');
 
     const unchanged = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'unchanged').length, 0);
     const modified  = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'modified').length, 0);
     const added     = frames.reduce((n, f) => n + f.blocks.filter(b => b.state === 'new').length, 0);
 
-    if (!frame.hasStoredSource && frames.length === 1) {
+    if (frame.sourceStatus === 'none' && frames.length === 1) {
         exportFrameInfo.textContent = 'No import history found.';
 
         const countText = added === 0
@@ -194,12 +195,12 @@ function renderReviewPanel(frameIndex: number) {
     while (exportReviewBlocks.firstChild) exportReviewBlocks.removeChild(exportReviewBlocks.firstChild);
 
     const reviewable = frame.blocks.filter(b => b.state !== 'unchanged');
-    const frameSelections = exportReviewSelections.get(frameIndex) ?? new Map<number, boolean>();
+    const frameSelections = exportReviewSelections.get(frameIndex) ?? new Map<number, 'use-original' | 'use-inferred' | 'skip'>();
 
     reviewable.forEach(block => {
         const blockIndex = frame.blocks.indexOf(block);
-        const defaultUseOriginal = block.state === 'modified';
-        const useOriginal = frameSelections.has(blockIndex) ? frameSelections.get(blockIndex)! : defaultUseOriginal;
+        const defaultAction: 'use-original' | 'use-inferred' | 'skip' = block.state === 'modified' ? 'use-original' : 'use-inferred';
+        const currentAction = frameSelections.get(blockIndex) ?? defaultAction;
 
         const el = document.createElement('div');
         el.className = `review-block review-block--${block.state}`;
@@ -253,13 +254,13 @@ function renderReviewPanel(frameIndex: number) {
         const actions = document.createElement('div');
         actions.className = 'review-block-actions';
 
-        const makeBtn = (label: string, blockIdx: number, useOrig: boolean, active: boolean) => {
+        const makeBtn = (label: string, blockIdx: number, selAction: 'use-original' | 'use-inferred' | 'skip', active: boolean) => {
             const btn = document.createElement('button');
             btn.className = `btn-review${active ? ' btn-review--active' : ''}`;
             btn.textContent = label;
             btn.addEventListener('click', () => {
-                const sel = exportReviewSelections.get(frameIndex) ?? new Map<number, boolean>();
-                sel.set(blockIdx, useOrig);
+                const sel = exportReviewSelections.get(frameIndex) ?? new Map<number, 'use-original' | 'use-inferred' | 'skip'>();
+                sel.set(blockIdx, selAction);
                 exportReviewSelections.set(frameIndex, sel);
                 renderReviewPanel(frameIndex);
             });
@@ -267,11 +268,11 @@ function renderReviewPanel(frameIndex: number) {
         };
 
         if (block.state === 'modified') {
-            actions.appendChild(makeBtn('✓ Keep original', blockIndex, true, useOriginal));
-            actions.appendChild(makeBtn('Use current', blockIndex, false, !useOriginal));
+            actions.appendChild(makeBtn('✓ Keep original', blockIndex, 'use-original', currentAction === 'use-original'));
+            actions.appendChild(makeBtn('Use current',     blockIndex, 'use-inferred', currentAction === 'use-inferred'));
         } else {
-            actions.appendChild(makeBtn('✓ Include', blockIndex, false, !useOriginal));
-            actions.appendChild(makeBtn('Skip', blockIndex, true, useOriginal));
+            actions.appendChild(makeBtn('✓ Include', blockIndex, 'use-inferred', currentAction === 'use-inferred'));
+            actions.appendChild(makeBtn('Skip',      blockIndex, 'skip',         currentAction === 'skip'));
         }
 
         el.appendChild(actions);
@@ -293,23 +294,28 @@ function triggerDownload(filename: string, content: string): boolean {
         console.error('[MarkDown For What] Download failed:', err);
         return false;
     } finally {
-        if (url) URL.revokeObjectURL(url);
+        if (url) {
+            const urlToRevoke = url;
+            setTimeout(() => URL.revokeObjectURL(urlToRevoke), 60_000);
+        }
     }
 }
 
-function downloadFrame(frameIndex: number) {
+function downloadFrame(frameIndex: number, batchId = downloadBatchId) {
     const frame = exportFrameResults[frameIndex];
     if (!frame) return;
     const sel = exportReviewSelections.get(frameIndex);
     const selections: BlockSelection[] = sel
-        ? Array.from(sel.entries()).map(([blockIndex, useOriginal]) => ({ blockIndex, useOriginal }))
+        ? Array.from(sel.entries()).map(([blockIndex, action]) => ({ blockIndex, action }))
         : [];
-    parent.postMessage({ pluginMessage: { type: MSG_EXPORT_DOWNLOAD, frameId: frame.frameId, selections } }, '*');
+    parent.postMessage({ pluginMessage: { type: MSG_EXPORT_DOWNLOAD, frameId: frame.frameId, selections, batchId } }, '*');
 }
 
 function startSequentialDownload() {
     pendingDownloadIndex = 0;
-    downloadFrame(pendingDownloadIndex);
+    downloadBatchId++;
+    const batchId = downloadBatchId;
+    downloadFrame(pendingDownloadIndex, batchId);
 }
 
 function renderExportLog(frames: ExportFrameResult[]) {
@@ -868,6 +874,7 @@ window.onmessage = event => {
             renderExportLog(msg.frames);
             break;
         case MSG_EXPORT_MARKDOWN: {
+            if (msg.batchId !== downloadBatchId) break; // stale batch — ignore
             const success = triggerDownload(msg.filename, msg.content);
             if (!success) {
                 // triggerDownload already logged; show user-visible feedback via existing status mechanism

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -8,6 +8,7 @@ import {
     MSG_STATUS, MSG_SETTINGS, MSG_LOCAL_STYLES, MSG_LOCAL_COMPONENTS, MSG_HISTORY,
     MSG_EXPORT_REQUEST, MSG_EXPORT_DOWNLOAD, MSG_GET_SELECTION,
     MSG_EXPORT_RESULT, MSG_EXPORT_MARKDOWN, MSG_SELECTION_CHANGED,
+    STATUS_DOMAIN_EXPORT,
 } from '../messages';
 import type { ExportBlock, BlockSelection, ExportFrameResult } from '../exporter';
 
@@ -829,7 +830,7 @@ window.onmessage = event => {
             importBtn.disabled = currentFiles.length === 0;
             showStatus(msg.message, msg.error ? 'error' : msg.warning ? 'warning' : 'success');
             // Clear paste area on successful import (but not for export-domain status messages)
-            if (!msg.error && msg.domain !== 'export') {
+            if (!msg.error && msg.domain !== STATUS_DOMAIN_EXPORT) {
                 pasteArea.value = '';
                 pasteName.value = '';
                 pasteImportBtn.disabled = true;

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -882,7 +882,9 @@ window.onmessage = event => {
             }
             pendingDownloadIndex++;
             if (pendingDownloadIndex < exportFrameResults.length) {
-                setTimeout(() => downloadFrame(pendingDownloadIndex), DOWNLOAD_STAGGER_MS);
+                const nextIndex = pendingDownloadIndex;
+                const thisBatchId = downloadBatchId;
+                setTimeout(() => downloadFrame(nextIndex, thisBatchId), DOWNLOAD_STAGGER_MS);
             }
             break;
         }

--- a/figma-markdown-sync/src/ui.ts
+++ b/figma-markdown-sync/src/ui.ts
@@ -116,6 +116,7 @@ let exportFrameResults: ExportFrameResult[] = [];
 let exportReviewSelections: Map<number, Map<number, boolean>> = new Map();
 let exportCurrentFrameIndex = 0;
 let pendingDownloadIndex = 0;
+const DOWNLOAD_STAGGER_MS = 300; // delay between sequential downloads to avoid browser throttling
 
 // ── Export UI helpers ────────────────────────────────────────────────────────
 
@@ -863,7 +864,7 @@ window.onmessage = event => {
             triggerDownload(msg.filename, msg.content);
             pendingDownloadIndex++;
             if (pendingDownloadIndex < exportFrameResults.length) {
-                setTimeout(() => downloadFrame(pendingDownloadIndex), 300);
+                setTimeout(() => downloadFrame(pendingDownloadIndex), DOWNLOAD_STAGGER_MS);
             }
             break;
         default:

--- a/figma-markdown-sync/test-setup.ts
+++ b/figma-markdown-sync/test-setup.ts
@@ -114,7 +114,9 @@ function makeMockRectangle(): any {
         appendChild: jest.fn(),
         findAll: jest.fn(() => []),
         findAllWithCriteria: jest.fn(() => []),
+        findOne: jest.fn(() => null),
         children: [],
+        selection: [],
     },
     editorType: 'figma',
     loadFontAsync: jest.fn().mockResolvedValue(undefined),
@@ -140,6 +142,7 @@ function makeMockRectangle(): any {
         setAsync: jest.fn().mockResolvedValue(undefined),
     },
     closePlugin: jest.fn(),
+    on: jest.fn(),
 };
 
 (global as any).__html__ = '';

--- a/figma-markdown-sync/test-setup.ts
+++ b/figma-markdown-sync/test-setup.ts
@@ -47,6 +47,9 @@ function makeMockFrame(): any {
             child.parent = frame;
         }),
         remove: jest.fn(),
+        _pluginData: {} as Record<string, string>,
+        setPluginData: jest.fn(function(key: string, value: string) { frame._pluginData[key] = value; }),
+        getPluginData: jest.fn(function(key: string) { return frame._pluginData[key] ?? ''; }),
     };
     return frame;
 }

--- a/figma-markdown-sync/ui.html
+++ b/figma-markdown-sync/ui.html
@@ -12,6 +12,7 @@
         <button class="tab active" data-tab="import">Import</button>
         <button class="tab" data-tab="history">History</button>
         <button class="tab" data-tab="settings">Settings</button>
+        <button class="tab" data-tab="export">Export</button>
     </nav>
 
     <!-- Import tab -->
@@ -180,6 +181,39 @@
             <button id="reset-btn" class="btn-secondary">Reset to defaults</button>
         </div>
 
+    </div>
+
+    <!-- Export tab -->
+    <div id="tab-export" class="tab-panel hidden">
+        <div id="export-no-selection" class="export-empty">
+            <p>Select one or more frames on the canvas to export them as Markdown.</p>
+        </div>
+
+        <div id="export-frame-summary" hidden>
+            <div id="export-frame-info"></div>
+            <div id="export-block-counts"></div>
+            <div id="export-truncated-warning" class="export-warning" hidden>
+                Source too large to store — using current state only.
+            </div>
+            <div id="export-actions">
+                <button id="export-btn" class="btn-primary" disabled>Export .md</button>
+                <button id="export-review-btn" class="btn-secondary" hidden>Review changes</button>
+            </div>
+        </div>
+
+        <div id="export-review-panel" hidden>
+            <div id="export-review-breadcrumb" hidden></div>
+            <div id="export-review-blocks"></div>
+            <button id="export-review-back" class="btn-link">Back to export</button>
+            <button id="export-confirm-btn" class="btn-primary">Export .md</button>
+        </div>
+
+        <div id="export-log-panel" hidden>
+            <details>
+                <summary>Export log</summary>
+                <pre id="export-log-content"></pre>
+            </details>
+        </div>
     </div>
 
     <!-- Loading overlay -->


### PR DESCRIPTION
## Summary

- Adds a full round-trip export pipeline: Figma frames → `.md` files
- Stores original Markdown source as `pluginData` at import time; `unchanged` blocks use the original text on export (preserving inline links, footnotes, badge syntax that can't survive the render cycle)
- Layer-tree inference engine covers all 18 block types using `Markdown/*` text styles and frame names
- Content-hash diff engine (insertion-tolerant) produces `unchanged` / `modified` / `new` block states
- New Export tab with summary view, selective block-by-block review mode, and sequential multi-file download

## What's new

- `exporter.ts` — inference engine, diff engine, assembly pipeline (333 tests, 95%+ coverage)
- Export tab in plugin UI — summary counts, review mode with per-block accept/reject, export log
- `pluginData` storage on import — `markdownSource`, `markdownFilename`, `markdownImportedAt` (≤50 KB; truncated flag otherwise)
- `mermaidSource` / `mathSource` stored at render time for round-trip recovery
- `MSG_EXPORT_REQUEST` / `MSG_EXPORT_DOWNLOAD` / `MSG_SELECTION_CHANGED` message types

## Test plan

- [ ] Import a `.md` file with headings, paragraphs, inline links, and a table
- [ ] Open Export tab → verify unchanged/modified/added counts appear
- [ ] Click Export .md → verify downloaded file matches original source (inline links preserved)
- [ ] Edit a paragraph in Figma → re-open Export tab → verify "1 modified" appears
- [ ] Click Review changes → verify diff panel shows original vs current with "Keep original" defaulted
- [ ] Toggle "Use current" → export → verify edited text in download
- [ ] Select a never-imported frame → verify "No import history found" state and inference-only export
- [ ] Select 0 frames → verify empty state message
- [ ] Select 2+ frames → click Export all → verify sequential `.md` downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)